### PR TITLE
Yard doc improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
           bundler: default
           bundler-cache: true
       - name: Build docs
-        run: bundle exec rake yard
+        run: bundle exec yardoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--fail-on-warning lib/**/*.rb - **/*.md LICENSE.txt

--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,1 @@
---fail-on-warning lib/**/*.rb - **/*.md LICENSE.txt
+--fail-on-warning lib/**/*.rb - **/*.md examples/**/*.rb LICENSE.txt

--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,0 @@
---fail-on-warning lib/**/*.rb - **/*.md examples/**/*.rb LICENSE.txt

--- a/Rakefile
+++ b/Rakefile
@@ -14,5 +14,4 @@ Rake::Task["spec"].enhance do
 end
 
 YARD::Rake::YardocTask.new do |t|
-  t.options = ["--fail-on-warning"]
 end

--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -38,7 +38,6 @@ module Langchain
     autoload :Database, "langchain/tool/database"
   end
 
-  # Processors load and parse/process various data types such as CSVs, PDFs, Word documents, HTML pages, and others.
   module Processors
     autoload :Base, "langchain/processors/base"
     autoload :CSV, "langchain/processors/csv"
@@ -55,7 +54,6 @@ module Langchain
     autoload :TokenLengthValidator, "langchain/utils/token_length_validator"
   end
 
-  # Vector database is a type of database that stores data as high-dimensional vectors, which are mathematical representations of features or attributes. Each vector has a certain number of dimensions, which can range from tens to thousands, depending on the complexity and granularity of the data.
   module Vectorsearch
     autoload :Base, "langchain/vectorsearch/base"
     autoload :Chroma, "langchain/vectorsearch/chroma"
@@ -76,7 +74,6 @@ module Langchain
     autoload :Replicate, "langchain/llm/replicate"
   end
 
-  # Prompts are structured inputs to the LLMs. Prompts provide instructions, context and other user input that LLMs use to generate responses.
   module Prompt
     require_relative "langchain/prompt/loading"
 

--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -7,41 +7,41 @@ require "colorize"
 require_relative "./langchain/version"
 
 # Langchain.rb a is library for building LLM-backed Ruby applications. It is an abstraction layer that sits on top of the emerging AI-related tools that makes it easy for developers to consume and string those services together.
-# 
+#
 # = Installation
 # Install the gem and add to the application's Gemfile by executing:
 #
 #     $ bundle add langchainrb
-# 
+#
 # If bundler is not being used to manage dependencies, install the gem by executing:
 #
 #     $ gem install langchainrb
-# 
+#
 # Require the gem to start using it:
 #
 #     require "langchain"
-# 
+#
 # = Concepts
 #
 # == Processors
 # Processors load and parse/process various data types such as CSVs, PDFs, Word documents, HTML pages, and others.
-# 
+#
 # == Chunkers
 # Chunkers split data based on various available options such as delimeters, chunk sizes or custom-defined functions. Chunkers are used when data needs to be split up before being imported in vector databases.
-# 
+#
 # == Prompts
 # Prompts are structured inputs to the LLMs. Prompts provide instructions, context and other user input that LLMs use to generate responses.
-# 
+#
 # == Large Language Models (LLMs)
 # LLM is a language model consisting of a neural network with many parameters (typically billions of weights or more), trained on large quantities of unlabeled text using self-supervised learning or semi-supervised learning.
-# 
+#
 # == Vectorsearch Databases
 # Vector database is a type of database that stores data as high-dimensional vectors, which are mathematical representations of features or attributes. Each vector has a certain number of dimensions, which can range from tens to thousands, depending on the complexity and granularity of the data.
-# 
+#
 # == Embedding
 # Word embedding or word vector is an approach with which we represent documents and words. It is defined as a numeric vector input that allows words with similar meanings to have the same representation. It can approximate meaning and represent a word in a lower dimensional space.
-# 
-# 
+#
+#
 # = Logging
 #
 # LangChain.rb uses standard logging mechanisms and defaults to :debug level. Most messages are at info level, but we will add debug or warn statements as needed. To show all log messages:

--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -8,8 +8,10 @@ require_relative "./langchain/version"
 
 module Langchain
   class << self
+    # @return [Logger]
     attr_accessor :logger
 
+    # @return [Pathname]
     attr_reader :root
   end
 
@@ -36,6 +38,7 @@ module Langchain
     autoload :Database, "langchain/tool/database"
   end
 
+  # Processors load and parse/process various data types such as CSVs, PDFs, Word documents, HTML pages, and others.
   module Processors
     autoload :Base, "langchain/processors/base"
     autoload :CSV, "langchain/processors/csv"
@@ -52,6 +55,7 @@ module Langchain
     autoload :TokenLengthValidator, "langchain/utils/token_length_validator"
   end
 
+  # Vector database is a type of database that stores data as high-dimensional vectors, which are mathematical representations of features or attributes. Each vector has a certain number of dimensions, which can range from tens to thousands, depending on the complexity and granularity of the data.
   module Vectorsearch
     autoload :Base, "langchain/vectorsearch/base"
     autoload :Chroma, "langchain/vectorsearch/chroma"
@@ -61,6 +65,7 @@ module Langchain
     autoload :Qdrant, "langchain/vectorsearch/qdrant"
     autoload :Weaviate, "langchain/vectorsearch/weaviate"
   end
+
 
   module LLM
     autoload :AI21, "langchain/llm/ai21"
@@ -72,6 +77,7 @@ module Langchain
     autoload :Replicate, "langchain/llm/replicate"
   end
 
+  # Prompts are structured inputs to the LLMs. Prompts provide instructions, context and other user input that LLMs use to generate responses.
   module Prompt
     require_relative "langchain/prompt/loading"
 

--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -6,6 +6,47 @@ require "colorize"
 
 require_relative "./langchain/version"
 
+# Langchain.rb a is library for building LLM-backed Ruby applications. It is an abstraction layer that sits on top of the emerging AI-related tools that makes it easy for developers to consume and string those services together.
+# 
+# = Installation
+# Install the gem and add to the application's Gemfile by executing:
+#
+#     $ bundle add langchainrb
+# 
+# If bundler is not being used to manage dependencies, install the gem by executing:
+#
+#     $ gem install langchainrb
+# 
+# Require the gem to start using it:
+#
+#     require "langchain"
+# 
+# = Concepts
+#
+# == Processors
+# Processors load and parse/process various data types such as CSVs, PDFs, Word documents, HTML pages, and others.
+# 
+# == Chunkers
+# Chunkers split data based on various available options such as delimeters, chunk sizes or custom-defined functions. Chunkers are used when data needs to be split up before being imported in vector databases.
+# 
+# == Prompts
+# Prompts are structured inputs to the LLMs. Prompts provide instructions, context and other user input that LLMs use to generate responses.
+# 
+# == Large Language Models (LLMs)
+# LLM is a language model consisting of a neural network with many parameters (typically billions of weights or more), trained on large quantities of unlabeled text using self-supervised learning or semi-supervised learning.
+# 
+# == Vectorsearch Databases
+# Vector database is a type of database that stores data as high-dimensional vectors, which are mathematical representations of features or attributes. Each vector has a certain number of dimensions, which can range from tens to thousands, depending on the complexity and granularity of the data.
+# 
+# == Embedding
+# Word embedding or word vector is an approach with which we represent documents and words. It is defined as a numeric vector input that allows words with similar meanings to have the same representation. It can approximate meaning and represent a word in a lower dimensional space.
+# 
+# 
+# = Logging
+#
+# LangChain.rb uses standard logging mechanisms and defaults to :debug level. Most messages are at info level, but we will add debug or warn statements as needed. To show all log messages:
+#
+#     Langchain.logger.level = :info
 module Langchain
   class << self
     # @return [Logger]

--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -66,7 +66,6 @@ module Langchain
     autoload :Weaviate, "langchain/vectorsearch/weaviate"
   end
 
-
   module LLM
     autoload :AI21, "langchain/llm/ai21"
     autoload :Base, "langchain/llm/base"

--- a/lib/langchain/agent/base.rb
+++ b/lib/langchain/agent/base.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 module Langchain::Agent
+  # = Agents
+  #
+  # Agents are semi-autonomous bots that can respond to user questions and use available to them Tools to provide informed replies. They break down problems into series of steps and define Actions (and Action Inputs) along the way that are executed and fed back to them as additional information. Once an Agent decides that it has the Final Answer it responds with it.
+  #
+  # Available:
+  # - {Langchain::Agent::ChainOfThoughtAgent}
+  #
+  # @abstract
   class Base
   end
 end

--- a/lib/langchain/agent/chain_of_thought_agent/chain_of_thought_agent.rb
+++ b/lib/langchain/agent/chain_of_thought_agent/chain_of_thought_agent.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 module Langchain::Agent
+  # = Chain of Thought Agent
+  #
+  #     llm = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"]) # or your choice of Langchain::LLM::Base implementation
+  #
+  #     agent = Langchain::Agent::ChainOfThoughtAgent.new(
+  #       llm: llm,
+  #       tools: ["search", "calculator", "wikipedia"]
+  #     )
+  #
+  #     agent.tools
+  #     # => ["search", "calculator", "wikipedia"]
+  #
+  #     agent.run(question: "How many full soccer fields would be needed to cover the distance between NYC and DC in a straight line?")
+  #     #=> "Approximately 2,945 soccer fields would be needed to cover the distance between NYC and DC in a straight line."
   class ChainOfThoughtAgent < Base
     attr_reader :llm, :tools
 

--- a/lib/langchain/llm/ai21.rb
+++ b/lib/langchain/llm/ai21.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 module Langchain::LLM
+  #
+  # Wrapper around AI21 Studio APIs.
+  #
+  # Gem requirements: gem "ai21", "~> 0.2.0"
+  #
+  # Usage:
+  #     ai21 = Langchain::LLM::AI21.new(api_key:)
+  #
   class AI21 < Base
-    #
-    # Wrapper around AI21 Studio APIs.
-    #
-    # Gem requirements: gem "ai21", "~> 0.2.0"
-    #
-    # Usage:
-    # ai21 = Langchain::LLM::AI21.new(api_key:)
-    #
-
     def initialize(api_key:)
       depends_on "ai21"
       require "ai21"

--- a/lib/langchain/llm/ai21.rb
+++ b/lib/langchain/llm/ai21.rb
@@ -4,7 +4,8 @@ module Langchain::LLM
   #
   # Wrapper around AI21 Studio APIs.
   #
-  # Gem requirements: gem "ai21", "~> 0.2.0"
+  # Gem requirements:
+  #   gem "ai21", "~> 0.2.0"
   #
   # Usage:
   #     ai21 = Langchain::LLM::AI21.new(api_key:)

--- a/lib/langchain/llm/base.rb
+++ b/lib/langchain/llm/base.rb
@@ -4,7 +4,7 @@ module Langchain::LLM
   # A LLM is a language model consisting of a neural network with many parameters (typically billions of weights or more), trained on large quantities of unlabeled text using self-supervised learning or semi-supervised learning.
   #
   # Langchain.rb provides a common interface to interact with all supported LLMs:
-  # 
+  #
   # - {Langchain::LLM::AI21}
   # - {Langchain::LLM::Cohere}
   # - {Langchain::LLM::GooglePalm}

--- a/lib/langchain/llm/base.rb
+++ b/lib/langchain/llm/base.rb
@@ -1,32 +1,71 @@
 # frozen_string_literal: true
 
 module Langchain::LLM
+  # A LLM is a language model consisting of a neural network with many parameters (typically billions of weights or more), trained on large quantities of unlabeled text using self-supervised learning or semi-supervised learning.
+  #
+  # Langchain.rb provides a common interface to interact with all supported LLMs:
+  # 
+  # - {Langchain::LLM::AI21}
+  # - {Langchain::LLM::Cohere}
+  # - {Langchain::LLM::GooglePalm}
+  # - {Langchain::LLM::HuggingFace}
+  # - {Langchain::LLM::OpenAI}
+  # - {Langchain::LLM::Replicate}
+  #
+  # @abstract
   class Base
     include Langchain::DependencyHelper
 
+    # A client for communicating with the LLM
     attr_reader :client
 
     def default_dimension
       self.class.const_get(:DEFAULTS).dig(:dimension)
     end
 
-    # Method supported by an LLM that generates a response for a given chat-style prompt
-    def chat(...)
+    #
+    # Generate a chat completion for a given prompt
+    #
+    # @param prompt [String] The prompt to generate a chat completion for
+    # @param params parameters LLM-specific parameters (if any) for chat
+    # @return [String] The chat completion
+    # @raise NotImplementedError if not supported by the LLM
+    #
+    def chat(prompt:, **params)
       raise NotImplementedError, "#{self.class.name} does not support chat"
     end
 
-    # Method supported by an LLM that completes a given prompt
-    def complete(...)
+    #
+    # Generate a completion for a given prompt
+    #
+    # @param prompt [String] The prompt to generate a completion for
+    # @param params parameters LLM-specific parameters (if any) for complete
+    # @return [String] The completion
+    # @raise NotImplementedError if not supported by the LLM
+    #
+    def complete(prompt:, **params)
       raise NotImplementedError, "#{self.class.name} does not support completion"
     end
 
-    # Method supported by an LLM that generates an embedding for a given text or array of texts
-    def embed(...)
+    #
+    # Generate an embedding for a given text
+    #
+    # @param text [String] The text to generate an embedding for
+    # @param params parameters LLM-specific parameters (if any) for embed
+    # @raise NotImplementedError if not supported by the LLM
+    #
+    def embed(text:, **params)
       raise NotImplementedError, "#{self.class.name} does not support generating embeddings"
     end
 
-    # Method supported by an LLM that summarizes a given text
-    def summarize(...)
+    #
+    # Generate a summary for a given text
+    #
+    # @param text [String] The text to generate a summary for
+    # @return [String] The summary
+    # @raise NotImplementedError if not supported by the LLM
+    #
+    def summarize(text:)
       raise NotImplementedError, "#{self.class.name} does not support summarization"
     end
   end

--- a/lib/langchain/llm/base.rb
+++ b/lib/langchain/llm/base.rb
@@ -24,48 +24,36 @@ module Langchain::LLM
     end
 
     #
-    # Generate a chat completion for a given prompt
+    # Generate a chat completion for a given prompt. Parameters will depend on the LLM
     #
-    # @param prompt [String] The prompt to generate a chat completion for
-    # @param params parameters LLM-specific parameters (if any) for chat
-    # @return [String] The chat completion
     # @raise NotImplementedError if not supported by the LLM
-    #
-    def chat(prompt:, **params)
+    def chat(...)
       raise NotImplementedError, "#{self.class.name} does not support chat"
     end
 
     #
-    # Generate a completion for a given prompt
+    # Generate a completion for a given prompt. Parameters will depend on the LLM.
     #
-    # @param prompt [String] The prompt to generate a completion for
-    # @param params parameters LLM-specific parameters (if any) for complete
-    # @return [String] The completion
     # @raise NotImplementedError if not supported by the LLM
-    #
-    def complete(prompt:, **params)
+    def complete(...)
       raise NotImplementedError, "#{self.class.name} does not support completion"
     end
 
     #
-    # Generate an embedding for a given text
+    # Generate an embedding for a given text. Parameters depends on the LLM.
     #
-    # @param text [String] The text to generate an embedding for
-    # @param params parameters LLM-specific parameters (if any) for embed
     # @raise NotImplementedError if not supported by the LLM
     #
-    def embed(text:, **params)
+    def embed(...)
       raise NotImplementedError, "#{self.class.name} does not support generating embeddings"
     end
 
     #
-    # Generate a summary for a given text
+    # Generate a summary for a given text. Parameters depends on the LLM.
     #
-    # @param text [String] The text to generate a summary for
-    # @return [String] The summary
     # @raise NotImplementedError if not supported by the LLM
     #
-    def summarize(text:)
+    def summarize(...)
       raise NotImplementedError, "#{self.class.name} does not support summarization"
     end
   end

--- a/lib/langchain/llm/cohere.rb
+++ b/lib/langchain/llm/cohere.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 module Langchain::LLM
+  #
+  # Wrapper around the Cohere API.
+  #
+  # Gem requirements:
+  #     gem "cohere-ruby", "~> 0.9.4"
+  #
+  # Usage:
+  #     cohere = Langchain::LLM::Cohere.new(api_key: "YOUR_API_KEY")
+  #
   class Cohere < Base
-    #
-    # Wrapper around the Cohere API.
-    #
-    # Gem requirements: gem "cohere-ruby", "~> 0.9.4"
-    #
-    # Usage:
-    # cohere = Langchain::LLM::Cohere.new(api_key: "YOUR_API_KEY")
-    #
-
     DEFAULTS = {
       temperature: 0.0,
       completion_model_name: "base",
@@ -43,6 +43,7 @@ module Langchain::LLM
     # Generate a completion for a given prompt
     #
     # @param prompt [String] The prompt to generate a completion for
+    # @param params[:stop_sequences]
     # @return [Hash] The completion
     #
     def complete(prompt:, **params)

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 module Langchain::LLM
+  #
+  # Wrapper around the Google PaLM (Pathways Language Model) APIs: https://ai.google/build/machine-learning/
+  #
+  # Gem requirements:
+  #     gem "google_palm_api", "~> 0.1.0"
+  #
+  # Usage:
+  #     google_palm = Langchain::LLM::GooglePalm.new(api_key: "YOUR_API_KEY")
+  #
   class GooglePalm < Base
-    #
-    # Wrapper around the Google PaLM (Pathways Language Model) APIs.
-    #
-    # Gem requirements: gem "google_palm_api", "~> 0.1.0"
-    #
-    # Usage:
-    # google_palm = Langchain::LLM::GooglePalm.new(api_key: "YOUR_API_KEY")
-    #
 
     DEFAULTS = {
       temperature: 0.0,
@@ -40,6 +41,7 @@ module Langchain::LLM
     # Generate a completion for a given prompt
     #
     # @param prompt [String] The prompt to generate a completion for
+    # @param params extra parameters passed to GooglePalmAPI::Client#generate_text
     # @return [String] The completion
     #
     def complete(prompt:, **params)
@@ -66,6 +68,7 @@ module Langchain::LLM
     # Generate a chat completion for a given prompt
     #
     # @param prompt [String] The prompt to generate a chat completion for
+    # @param params extra parameters passed to GooglePalmAPI::Client#generate_chat_message
     # @return [String] The chat completion
     #
     def chat(prompt:, **params)

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -11,7 +11,6 @@ module Langchain::LLM
   #     google_palm = Langchain::LLM::GooglePalm.new(api_key: "YOUR_API_KEY")
   #
   class GooglePalm < Base
-
     DEFAULTS = {
       temperature: 0.0,
       dimension: 768 # This is what the `embedding-gecko-001` model generates

--- a/lib/langchain/llm/hugging_face.rb
+++ b/lib/langchain/llm/hugging_face.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 module Langchain::LLM
+  #
+  # Wrapper around the HuggingFace Inference API: https://huggingface.co/inference-api
+  #
+  # Gem requirements:
+  #     gem "hugging-face", "~> 0.3.4"
+  #
+  # Usage:
+  #     hf = Langchain::LLM::HuggingFace.new(api_key: "YOUR_API_KEY")
+  #
   class HuggingFace < Base
-    #
-    # Wrapper around the HuggingFace Inference API.
-    #
-    # Gem requirements: gem "hugging-face", "~> 0.3.4"
-    #
-    # Usage:
-    # hf = Langchain::LLM::HuggingFace.new(api_key: "YOUR_API_KEY")
-    #
-
     # The gem does not currently accept other models:
     # https://github.com/alchaplinsky/hugging-face/blob/main/lib/hugging_face/inference_api.rb#L32-L34
     DEFAULTS = {

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -10,7 +10,6 @@ module Langchain::LLM
   #    openai = Langchain::LLM::OpenAI.new(api_key:, llm_options: {})
   #
   class OpenAI < Base
-
     DEFAULTS = {
       temperature: 0.0,
       completion_model_name: "text-davinci-003",

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module Langchain::LLM
+  # LLM interface for OpenAI APIs: https://platform.openai.com/overview
+  #
+  # Gem requirements:
+  #    gem "ruby-openai", "~> 4.0.0"
+  #
+  # Usage:
+  #    openai = Langchain::LLM::OpenAI.new(api_key:, llm_options: {})
+  #
   class OpenAI < Base
-    #
-    # Wrapper around OpenAI APIs.
-    #
-    # Gem requirements: gem "ruby-openai", "~> 4.0.0"
-    #
-    # Usage:
-    # openai = Langchain::LLM::OpenAI.new(api_key:, llm_options: {})
-    #
 
     DEFAULTS = {
       temperature: 0.0,
@@ -30,6 +30,7 @@ module Langchain::LLM
     # Generate an embedding for a given text
     #
     # @param text [String] The text to generate an embedding for
+    # @param params extra parameters passed to OpenAI::Client#embeddings
     # @return [Array] The embedding
     #
     def embed(text:, **params)
@@ -45,6 +46,7 @@ module Langchain::LLM
     # Generate a completion for a given prompt
     #
     # @param prompt [String] The prompt to generate a completion for
+    # @param params  extra parameters passed to OpenAI::Client#complete
     # @return [String] The completion
     #
     def complete(prompt:, **params)
@@ -61,6 +63,7 @@ module Langchain::LLM
     # Generate a chat completion for a given prompt
     #
     # @param prompt [String] The prompt to generate a chat completion for
+    # @param params extra parameters passed to OpenAI::Client#chat
     # @return [String] The chat completion
     #
     def chat(prompt:, **params)

--- a/lib/langchain/llm/replicate.rb
+++ b/lib/langchain/llm/replicate.rb
@@ -8,13 +8,13 @@ module Langchain::LLM
   #     gem "replicate-ruby", "~> 0.2.2"
   #
   # Use it directly:
-  #     replicate = LLM::Replicate.new(api_key: ENV["REPLICATE_API_KEY"])
+  #     replicate = Langchain::LLM::Replicate.new(api_key: ENV["REPLICATE_API_KEY"])
   #
-  # Or pass it to be instantiated by a vector search DB:
-  #     chroma = Vectorsearch::Chroma.new(
+  # Or pass it to be used by a vector search DB:
+  #     chroma = Langchain::Vectorsearch::Chroma.new(
   #       url: ENV["CHROMA_URL"],
   #       index_name: "...",
-  #       llm: Langchain::LLM::Replicate(api_key: ENV["REPLICATE_API_KEY"])
+  #       llm: replicate
   #     )
   #
   class Replicate < Base

--- a/lib/langchain/llm/replicate.rb
+++ b/lib/langchain/llm/replicate.rb
@@ -18,7 +18,6 @@ module Langchain::LLM
   #     )
   #
   class Replicate < Base
-
     DEFAULTS = {
       # TODO: Figure out how to send the temperature to the API
       temperature: 0.01, # Minimum accepted value

--- a/lib/langchain/llm/replicate.rb
+++ b/lib/langchain/llm/replicate.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
 module Langchain::LLM
+  #
+  # Wrapper around Replicate.com LLM provider
+  #
+  # Gem requirements:
+  #     gem "replicate-ruby", "~> 0.2.2"
+  #
+  # Use it directly:
+  #     replicate = LLM::Replicate.new(api_key: ENV["REPLICATE_API_KEY"])
+  #
+  # Or pass it to be instantiated by a vector search DB:
+  #     chroma = Vectorsearch::Chroma.new(
+  #       url: ENV["CHROMA_URL"],
+  #       index_name: "...",
+  #       llm: Langchain::LLM::Replicate(api_key: ENV["REPLICATE_API_KEY"])
+  #     )
+  #
   class Replicate < Base
-    #
-    # Wrapper around Replicate.com LLM provider
-    #
-    # Gem requirements: gem "replicate-ruby", "~> 0.2.2"
-    #
-    # Use it directly:
-    # replicate = LLM::Replicate.new(api_key: ENV["REPLICATE_API_KEY"])
-    #
-    # Or pass it to be instantiated by a vector search DB:
-    # chroma = Vectorsearch::Chroma.new(
-    #   url: ENV["CHROMA_URL"],
-    #   index_name: "...",
-    #   llm: Langchain::LLM::Replicate(api_key: ENV["REPLICATE_API_KEY"])
-    # )
 
     DEFAULTS = {
       # TODO: Figure out how to send the temperature to the API

--- a/lib/langchain/processors/base.rb
+++ b/lib/langchain/processors/base.rb
@@ -2,6 +2,7 @@
 
 module Langchain
   module Processors
+    # Processors load and parse/process various data types such as CSVs, PDFs, Word documents, HTML pages, and others.
     class Base
       include Langchain::DependencyHelper
 

--- a/lib/langchain/prompt/base.rb
+++ b/lib/langchain/prompt/base.rb
@@ -5,15 +5,20 @@ require "json"
 require "yaml"
 
 module Langchain::Prompt
+  # Prompts are structured inputs to the LLMs. Prompts provide instructions, context and other user input that LLMs use to generate responses.
+  #
+  # @abstract
   class Base
     def format(**kwargs)
       raise NotImplementedError
     end
 
+    # @return [String] the type of the prompt
     def prompt_type
       raise NotImplementedError
     end
 
+    # @return [Hash] a hash representation of the prompt
     def to_h
       raise NotImplementedError
     end

--- a/lib/langchain/prompt/few_shot_prompt_template.rb
+++ b/lib/langchain/prompt/few_shot_prompt_template.rb
@@ -2,7 +2,7 @@
 
 module Langchain::Prompt
   # = Few Shot Prompt Templates
-  # 
+  #
   # Create a prompt with a few shot examples:
   #
   #     prompt = Langchain::Prompt::FewShotPromptTemplate.new(
@@ -18,9 +18,9 @@ module Langchain::Prompt
   #       ],
   #        input_variables: ["adjective"]
   #     )
-  #     
+  #
   #     prompt.format(adjective: "good")
-  #     
+  #
   #     # Write antonyms for the following words.
   #     #
   #     # Input: happy
@@ -31,11 +31,11 @@ module Langchain::Prompt
   #     #
   #     # Input: good
   #     # Output:
-  # 
+  #
   # Save prompt template to JSON file:
   #
   #     prompt.save(file_path: "spec/fixtures/prompt/few_shot_prompt_template.json")
-  # 
+  #
   # Loading a new prompt template using a JSON file:
   #
   #     prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/few_shot_prompt_template.json")

--- a/lib/langchain/prompt/few_shot_prompt_template.rb
+++ b/lib/langchain/prompt/few_shot_prompt_template.rb
@@ -41,6 +41,10 @@ module Langchain::Prompt
   #     prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/few_shot_prompt_template.json")
   #     prompt.prefix # "Write antonyms for the following words."
   #
+  # Loading a new prompt template using a YAML file:
+  #     prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/prompt_template.yaml")
+  #     prompt.input_variables #=> ["adjective", "content"]
+  #
   class FewShotPromptTemplate < Base
     attr_reader :examples, :example_prompt, :input_variables, :prefix, :suffix, :example_separator
 

--- a/lib/langchain/prompt/few_shot_prompt_template.rb
+++ b/lib/langchain/prompt/few_shot_prompt_template.rb
@@ -1,6 +1,46 @@
 # frozen_string_literal: true
 
 module Langchain::Prompt
+  # = Few Shot Prompt Templates
+  # 
+  # Create a prompt with a few shot examples:
+  #
+  #     prompt = Langchain::Prompt::FewShotPromptTemplate.new(
+  #       prefix: "Write antonyms for the following words.",
+  #       suffix: "Input: <code>{adjective}</code>\nOutput:",
+  #       example_prompt: Langchain::Prompt::PromptTemplate.new(
+  #         input_variables: ["input", "output"],
+  #         template: "Input: {input}\nOutput: {output}"
+  #       ),
+  #       examples: [
+  #         { "input": "happy", "output": "sad" },
+  #         { "input": "tall", "output": "short" }
+  #       ],
+  #        input_variables: ["adjective"]
+  #     )
+  #     
+  #     prompt.format(adjective: "good")
+  #     
+  #     # Write antonyms for the following words.
+  #     #
+  #     # Input: happy
+  #     # Output: sad
+  #     #
+  #     # Input: tall
+  #     # Output: short
+  #     #
+  #     # Input: good
+  #     # Output:
+  # 
+  # Save prompt template to JSON file:
+  #
+  #     prompt.save(file_path: "spec/fixtures/prompt/few_shot_prompt_template.json")
+  # 
+  # Loading a new prompt template using a JSON file:
+  #
+  #     prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/few_shot_prompt_template.json")
+  #     prompt.prefix # "Write antonyms for the following words."
+  #
   class FewShotPromptTemplate < Base
     attr_reader :examples, :example_prompt, :input_variables, :prefix, :suffix, :example_separator
 

--- a/lib/langchain/prompt/few_shot_prompt_template.rb
+++ b/lib/langchain/prompt/few_shot_prompt_template.rb
@@ -42,6 +42,7 @@ module Langchain::Prompt
   #     prompt.prefix # "Write antonyms for the following words."
   #
   # Loading a new prompt template using a YAML file:
+  #
   #     prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/prompt_template.yaml")
   #     prompt.input_variables #=> ["adjective", "content"]
   #

--- a/lib/langchain/prompt/prompt_template.rb
+++ b/lib/langchain/prompt/prompt_template.rb
@@ -27,6 +27,11 @@ module Langchain::Prompt
   #
   #     prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/prompt_template.json")
   #     prompt.input_variables # ["adjective", "content"]
+  #
+  # Loading a new prompt template using a YAML file:
+  #     prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/prompt_template.yaml")
+  #     prompt.input_variables #=> ["adjective", "content"]
+  #
   class PromptTemplate < Base
     attr_reader :template, :input_variables, :validate_template
 

--- a/lib/langchain/prompt/prompt_template.rb
+++ b/lib/langchain/prompt/prompt_template.rb
@@ -1,6 +1,33 @@
 # frozen_string_literal: true
 
 module Langchain::Prompt
+    
+  # = Prompt Templates
+  #
+  # Create a prompt with one input variable:
+  #
+  #     prompt = Langchain::Prompt::PromptTemplate.new(template: "Tell me a {adjective} joke.", input_variables: ["adjective"])
+  #     prompt.format(adjective: "funny") # "Tell me a funny joke."
+  # 
+  # Create a prompt with multiple input variables:
+  #
+  #     prompt = Langchain::Prompt::PromptTemplate.new(template: "Tell me a {adjective} joke about {content}.", input_variables: ["adjective", "content"])
+  #     prompt.format(adjective: "funny", content: "chickens") # "Tell me a funny joke about chickens."
+  # 
+  # Creating a PromptTemplate using just a prompt and no input_variables:
+  #
+  #     prompt = Langchain::Prompt::PromptTemplate.from_template("Tell me a {adjective} joke about {content}.")
+  #     prompt.input_variables # ["adjective", "content"]
+  #     prompt.format(adjective: "funny", content: "chickens") # "Tell me a funny joke about chickens."
+  # 
+  # Save prompt template to JSON file:
+  #
+  #     prompt.save(file_path: "spec/fixtures/prompt/prompt_template.json")
+  # 
+  # Loading a new prompt template using a JSON file:
+  #
+  #     prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/prompt_template.json")
+  #     prompt.input_variables # ["adjective", "content"]
   class PromptTemplate < Base
     attr_reader :template, :input_variables, :validate_template
 

--- a/lib/langchain/prompt/prompt_template.rb
+++ b/lib/langchain/prompt/prompt_template.rb
@@ -1,29 +1,28 @@
 # frozen_string_literal: true
 
 module Langchain::Prompt
-    
   # = Prompt Templates
   #
   # Create a prompt with one input variable:
   #
   #     prompt = Langchain::Prompt::PromptTemplate.new(template: "Tell me a {adjective} joke.", input_variables: ["adjective"])
   #     prompt.format(adjective: "funny") # "Tell me a funny joke."
-  # 
+  #
   # Create a prompt with multiple input variables:
   #
   #     prompt = Langchain::Prompt::PromptTemplate.new(template: "Tell me a {adjective} joke about {content}.", input_variables: ["adjective", "content"])
   #     prompt.format(adjective: "funny", content: "chickens") # "Tell me a funny joke about chickens."
-  # 
+  #
   # Creating a PromptTemplate using just a prompt and no input_variables:
   #
   #     prompt = Langchain::Prompt::PromptTemplate.from_template("Tell me a {adjective} joke about {content}.")
   #     prompt.input_variables # ["adjective", "content"]
   #     prompt.format(adjective: "funny", content: "chickens") # "Tell me a funny joke about chickens."
-  # 
+  #
   # Save prompt template to JSON file:
   #
   #     prompt.save(file_path: "spec/fixtures/prompt/prompt_template.json")
-  # 
+  #
   # Loading a new prompt template using a JSON file:
   #
   #     prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/prompt_template.json")

--- a/lib/langchain/tool/base.rb
+++ b/lib/langchain/tool/base.rb
@@ -1,15 +1,52 @@
 # frozen_string_literal: true
 
 module Langchain::Tool
+  # = Tools
+  #
+  # Tools are used by Agents to perform specific tasks. Basically anything is possible with enough code!
+  #
+  # == Available Tools
+  #
+  # - {Langchain::Tool::Calculator}: Calculate the result of a math expression
+  # - {Langchain::Tool::RubyCodeInterpretor}: Runs ruby code
+  # - {Langchain::Tool::Search}: search on Google (via SerpAPI)
+  # - {Langchain::Tool::Wikipedia}: search on Wikipedia
+  #
+  # == Usage
+  #
+  # 1. Pick the tools you'd like to pass to an Agent and install the gems listed under **Gem Requirements**
+  #
+  #     # To use all 3 tools:
+  #     gem install eqn
+  #     gem install google_search_results
+  #     gem install wikipedia-client
+  #
+  # 2. Set the environment variables listed under **ENV Requirements**
+  #
+  #     export SERPAPI_API_KEY=paste-your-serpapi-api-key-here
+  #
+  # 3. Pass the tools when Agent is instantiated.
+  #
+  #     agent = Langchain::Agent::ChainOfThoughtAgent.new(
+  #       llm: :openai, # or :cohere, :hugging_face, :google_palm or :replicate
+  #       llm_api_key: ENV["OPENAI_API_KEY"],
+  #       tools: ["search", "calculator", "wikipedia"]
+  #     )
+  #
+  # 4. Confirm that the Agent is using the Tools you passed in:
+  #
+  #     agent.tools
+  #     # => ["search", "calculator", "wikipedia"]
+  #
+  # == Adding Tools
+  #
+  # 1. Create a new file in lib/langchain/tool/your_tool_name.rb
+  # 2. Create a class in the file that inherits from {Langchain::Tool::Base}
+  # 3. Add `NAME=` and `DESCRIPTION=` constants in your Tool class
+  # 4. Implement `execute(input:)` method in your tool class
+  # 5. Add your tool to the {file:README.md}
   class Base
     include Langchain::DependencyHelper
-
-    # How to add additional Tools?
-    # 1. Create a new file in lib/tool/your_tool_name.rb
-    # 2. Create a class in the file that inherits from Langchain::Tool::Base
-    # 3. Add `NAME=` and `DESCRIPTION=` constants in your Tool class
-    # 4. Implement `execute(input:)` method in your tool class
-    # 5. Add your tool to the README.md
 
     #
     # Returns the NAME constant of the tool
@@ -44,7 +81,7 @@ module Langchain::Tool
     #
     # @param input [String] input to the tool
     # @return [String] answer
-    #
+    # @raise NotImplementedError when not implemented
     def execute(input:)
       raise NotImplementedError, "Your tool must implement the `#execute(input:)` method that returns a string"
     end

--- a/lib/langchain/vectorsearch/base.rb
+++ b/lib/langchain/vectorsearch/base.rb
@@ -3,6 +3,7 @@
 require "forwardable"
 
 module Langchain::Vectorsearch
+  # Vector database is a type of database that stores data as high-dimensional vectors, which are mathematical representations of features or attributes. Each vector has a certain number of dimensions, which can range from tens to thousands, depending on the complexity and granularity of the data.
   class Base
     include Langchain::DependencyHelper
     extend Forwardable

--- a/lib/langchain/vectorsearch/base.rb
+++ b/lib/langchain/vectorsearch/base.rb
@@ -3,7 +3,88 @@
 require "forwardable"
 
 module Langchain::Vectorsearch
-  # Vector database is a type of database that stores data as high-dimensional vectors, which are mathematical representations of features or attributes. Each vector has a certain number of dimensions, which can range from tens to thousands, depending on the complexity and granularity of the data.
+  # = Vector Databases
+  # A vector database a type of database that stores data as high-dimensional vectors, which are mathematical representations of features or attributes. Each vector has a certain number of dimensions, which can range from tens to thousands, depending on the complexity and granularity of the data.
+  #
+  # == Available vector databases
+  #
+  # - {Langchain::Vectorsearch::Chroma}
+  # - {Langchain::Vectorsearch::Milvus}
+  # - {Langchain::Vectorsearch::Pinecone}
+  # - {Langchain::Vectorsearch::Qdrant}
+  # - {Langchain::Vectorsearch::Weaviate}
+  # - {Langchain::Vectorsearch::Pgvector}
+  #
+  # == Usage
+  #
+  # 1. Pick a vector database from list.
+  # 2. Review its documentation to install the required gems, and create an account, get an API key, etc
+  # 3. Instantiate the vector database class:
+  #
+  #     weaviate = Langchain::Vectorsearch::Weaviate.new(
+  #       url:         ENV["WEAVIATE_URL"],
+  #       api_key:     ENV["WEAVIATE_API_KEY"],
+  #       index_name:  "Documents",
+  #       llm:         :openai,              # or :cohere, :hugging_face, :google_palm, or :replicate
+  #       llm_api_key: ENV["OPENAI_API_KEY"] # API key for the selected LLM
+  #     )
+  #
+  #     # You can instantiate other supported vector databases the same way:
+  #     milvus   = Langchain::Vectorsearch::Milvus.new(...)
+  #     qdrant   = Langchain::Vectorsearch::Qdrant.new(...)
+  #     pinecone = Langchain::Vectorsearch::Pinecone.new(...)
+  #     chrome   = Langchain::Vectorsearch::Chroma.new(...)
+  #     pgvector = Langchain::Vectorsearch::Pgvector.new(...)
+  #
+  # == Schema Creation
+  #
+  # `create_default_schema()` creates default schema in your vector database.
+  #
+  #     search.create_default_schema
+  #
+  # (We plan on offering customizable schema creation shortly)
+  #
+  # == Adding Data
+  #
+  # You can add data with:
+  # 1. `add_data(path:, paths:)` to add any kind of data type
+  #
+  #     my_pdf = Langchain.root.join("path/to/my.pdf")
+  #     my_text = Langchain.root.join("path/to/my.txt")
+  #     my_docx = Langchain.root.join("path/to/my.docx")
+  #     my_csv = Langchain.root.join("path/to/my.csv")
+  #
+  #     search.add_data(paths: [my_pdf, my_text, my_docx, my_csv])
+  #
+  # 2. `add_texts(texts:)` to only add textual data
+  #
+  #     search.add_texts(
+  #       texts: [
+  #         "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
+  #         "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s"
+  #       ]
+  #     )
+  #
+  # == Retrieving Data
+  #
+  # `similarity_search_by_vector(embedding:, k:)` searches the vector database for the closest `k` number of embeddings.
+  #
+  #    search.similarity_search_by_vector(
+  #      embedding: ...,
+  #      k: # number of results to be retrieved
+  #    )
+  #
+  # `vector_store.similarity_search(query:, k:)` generates an embedding for the query and searches the vector database for the closest `k` number of embeddings.
+  #
+  # search.similarity_search_by_vector(
+  #   embedding: ...,
+  #   k: # number of results to be retrieved
+  # )
+  #
+  # `ask(question:)` generates an embedding for the passed-in question, searches the vector database for closest embeddings and then passes these as context to the LLM to generate an answer to the question.
+  #
+  #     search.ask(question: "What is lorem ipsum?")
+  #
   class Base
     include Langchain::DependencyHelper
     extend Forwardable


### PR DESCRIPTION
I was chatting with @andreibondarev about including additional files in the YARD output. You could imagine moving the wiki into a docs folder, for example.

 I started doing that, by including all markdown files, the license, and example files... and then it kinda got out from under me 🤪 

I took a bunch of inspiration from how Rails organizes it's docs. For each "component", they put the docs on how to use them onto the Base class. So I did that. Here's a grab bag of changes:

- make sure the documentation is on the right constant (several were on the `Langchain::<Component>` for example)
- Add links to the LLM providers when possible
- Add the correct signature to LLM::Base methods. Document that they can pass in params to the client, and can raise notimplemented error if the LLM doesn't provide it
- changed triple backtick fencing to 4 spaces. it automatically renders code as ruby syntax

I kinda ran out of steam though, but figured this was a good spot to stop for feedback. I think there is some open questions about what type of docs go where, but probably better to discuss on https://github.com/andreibondarev/langchainrb/issues/54

sidenote: It's also worth noting... YARD syntax is different than Markdown, and slightly different than rdoc.