### PR TITLE
add stop_sequences for complete in ollama

### DIFF
--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -61,8 +61,12 @@ module Langchain::LLM
       num_predict: nil,
       top_k: nil,
       top_p: nil,
+      stop_sequences: nil,
       &block
     )
+      if stop_sequences
+        stop = stop_sequences
+      end
 
       parameters = {
         prompt: prompt,


### PR DESCRIPTION
The `ReActAgent` class employs the [complete](https://github.com/andreibondarev/langchainrb/blob/005c39b38b8d15bd0d0ed40cb819fb61d749d24d/lib/langchain/agent/react_agent.rb#L61) method, incorporating the `stop_sequences` parameter. However, when using Ollama, the `stop_sequences` parameter is not supported by the `complete` method. 
Now the `complete` method has been updated to accept the `stop_sequences` parameter, directly incorporating it into the `stop` parameter.