### PR TITLE
Optionally pass a block to OpenAI::Client.new

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -34,10 +34,10 @@ module Langchain::LLM
     #
     # @param api_key [String] The API key to use
     # @param client_options [Hash] Options to pass to the OpenAI::Client constructor
-    def initialize(api_key:, llm_options: {}, default_options: {})
+    def initialize(api_key:, llm_options: {}, default_options: {}, &llm_block)
       depends_on "ruby-openai", req: "openai"
 
-      @client = ::OpenAI::Client.new(access_token: api_key, **llm_options)
+      @client = ::OpenAI::Client.new(access_token: api_key, **llm_options, &llm_block)
 
       @defaults = DEFAULTS.merge(default_options)
     end


### PR DESCRIPTION
This block is ultimately passed to Faraday.

For example, to enable low-level faraday logging:

```ruby
llm = Langchain::LLM::OpenAI.new(api_key: ENV[OPENAI_API_KEY]) do |f|
  f.response :logger, Logger.new(), bodies: true
end
```

See more at https://github.com/alexrudall/ruby-openai?tab=readme-ov-file#verbose-logging