### PR TITLE
Ensure that default dimensions passed to LLM instance are respected by embed

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -185,7 +185,7 @@ module Langchain::LLM
     end
 
     def default_dimension
-      @defaults[:dimension] || EMBEDDING_SIZES.fetch(defaults[:embeddings_model_name])
+      @defaults[:dimensions] || EMBEDDING_SIZES.fetch(defaults[:embeddings_model_name])
     end
 
     private

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -54,7 +54,7 @@ module Langchain::LLM
       model: defaults[:embeddings_model_name],
       encoding_format: nil,
       user: nil,
-      dimensions: nil
+      dimensions: @defaults[:dimensions]
     )
       raise ArgumentError.new("text argument is required") if text.empty?
       raise ArgumentError.new("model argument is required") if model.empty?

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe Langchain::LLM::OpenAI do
       let(:subject) do
         described_class.new(api_key: "123", default_options: {
           embeddings_model_name: "text-embedding-3-small",
-          dimension: 512
+          dimensions: 512
         })
       end
 

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -184,16 +184,17 @@ RSpec.describe Langchain::LLM::OpenAI do
     end
 
     context "when dimensions are explicitly provided to the initialize default options" do
-      let(:subject) { described_class.new(api_key: "123", default_options: { dimensions: dimensions })}
-      let(:dimensions) { 999 }
-      let(:model) { "text-embedding-3-small" }
+      let(:subject) {described_class.new(api_key: "123", default_options: {dimensions: dimensions})}
+      let(:dimensions) {999}
+      let(:model) {"text-embedding-3-small"}
+      let(:text) {"Hello World"}
       let(:parameters) do
-        {parameters: {input: "Hello World", model: model, dimensions: dimensions}}
+        {parameters: {input: text, model: model, dimensions: dimensions}}
       end
 
       it "they are passed to the API" do
         allow(subject.client).to receive(:embeddings).with(parameters).and_return(response)
-        subject.embed(text: "Hello World", model: "text-embedding-3-small")
+        subject.embed(text: text, model: model)
 
         expect(subject.client).to have_received(:embeddings).with(parameters)
       end

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -184,10 +184,10 @@ RSpec.describe Langchain::LLM::OpenAI do
     end
 
     context "when dimensions are explicitly provided to the initialize default options" do
-      let(:subject) {described_class.new(api_key: "123", default_options: {dimensions: dimensions})}
-      let(:dimensions) {999}
-      let(:model) {"text-embedding-3-small"}
-      let(:text) {"Hello World"}
+      let(:subject) { described_class.new(api_key: "123", default_options: {dimensions: dimensions}) }
+      let(:dimensions) { 999 }
+      let(:model) { "text-embedding-3-small" }
+      let(:text) { "Hello World" }
       let(:parameters) do
         {parameters: {input: text, model: model, dimensions: dimensions}}
       end

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Langchain::LLM::OpenAI do
     end
 
     Langchain::LLM::OpenAI::EMBEDDING_SIZES.each do |model_key, dimensions|
-      model = model_key.to_s.delete(":") # Convertir el símbolo del modelo a string
+      model = model_key.to_s
 
       context "when using model #{model}" do
         let(:text) { "Hello World" }
@@ -178,6 +178,22 @@ RSpec.describe Langchain::LLM::OpenAI do
       it "they are passed to the API" do
         allow(subject.client).to receive(:embeddings).with(parameters).and_return(response)
         subject.embed(text: "Hello World", model: "text-embedding-3-small", dimensions: 999)
+
+        expect(subject.client).to have_received(:embeddings).with(parameters)
+      end
+    end
+
+    context "when dimensions are explicitly provided to the initialize default options" do
+      let(:subject) { described_class.new(api_key: "123", default_options: { dimensions: dimensions })}
+      let(:dimensions) { 999 }
+      let(:model) { "text-embedding-3-small" }
+      let(:parameters) do
+        {parameters: {input: "Hello World", model: model, dimensions: dimensions}}
+      end
+
+      it "they are passed to the API" do
+        allow(subject.client).to receive(:embeddings).with(parameters).and_return(response)
+        subject.embed(text: "Hello World", model: "text-embedding-3-small")
 
         expect(subject.client).to have_received(:embeddings).with(parameters)
       end


### PR DESCRIPTION
Related to: https://github.com/patterns-ai-core/langchainrb/issues/572

We need to set the embed dimensions in the LLM instance, otherwise we risk having one the Vector DB config set to a different dimension size to the dimensions returned by the embed method. 

Allow `dimensions` to be manually set in the `embed` method, but respect them if they are set in the LLM. 