### PR TITLE
Translate max_tokens_to_sample for OpenAI

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -112,6 +112,7 @@ module Langchain::LLM
       logprobs: nil,
       top_logprobs: nil,
       max_tokens: nil,
+      max_tokens_to_sample: nil,
       n: defaults[:n],
       presence_penalty: nil,
       response_format: nil,
@@ -128,6 +129,8 @@ module Langchain::LLM
       raise ArgumentError.new("messages argument is required") if messages.empty?
       raise ArgumentError.new("model argument is required") if model.empty?
       raise ArgumentError.new("'tool_choice' is only allowed when 'tools' are specified.") if tool_choice && tools.empty?
+
+      max_tokens ||= max_tokens_to_sample
 
       parameters = {
         messages: messages,

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -607,6 +607,19 @@ RSpec.describe Langchain::LLM::OpenAI do
         }.to raise_error(ArgumentError, "'tool_choice' is only allowed when 'tools' are specified.")
       end
     end
+
+    context "with max_tokens_to_sample" do
+      let(:max_tokens_to_sample) { 50000 }
+      let(:parameters) { {parameters: {n: n, messages: history, model: model, temperature: temperature, max_tokens: max_tokens_to_sample}} }
+
+      it "translates max_tokens_to_sample to max_tokens" do
+        allow(subject.client).to receive(:chat).and_return(response)
+
+        subject.chat(messages: history, max_tokens_to_sample: max_tokens_to_sample)
+
+        expect(subject.client).to have_received(:chat).with(parameters)
+      end
+    end
   end
 
   describe "#summarize" do


### PR DESCRIPTION
While attempting to use the semantic chunker with OpenAI, I ran into this issue:
```
[2] pry(main)> url = "https://www.scottcmoore.com"
data = Langchain::Loader.load(url).value
llm = LlmFactory.create!("OpenAI")
Langchain::Chunker::Semantic.new(
  data,
  llm: llm
DEPRECATED: `Langchain::LLM::OpenAI#complete` is deprecated, and will be removed in the next major version. Use `Langchain::LLM::OpenAI#chat` instead.
ArgumentError: unknown keyword: :max_tokens_to_sample
```

OpenAI expects this parameter as 'max_tokens', while other providers appear to expect 'max_tokens_to_sample'. This PR updates the OpenAI chat method to accept either version of the parameter. 
Let me know what you think of this approach, thanks!