### PR TITLE
0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.11.4] - 2024-04-19
+- New `Langchain::LLM::AWSBedrock#chat()` to wrap Bedrock Claude requests
+- New `Langchain::LLM::OllamaResponse#total_tokens()` method
+
 ## [0.11.3] - 2024-04-16
 - New `Langchain::Processors::Pptx` to parse .pptx files
 - New `Langchain::LLM::Anthropic#chat()` support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    langchainrb (0.11.3)
+    langchainrb (0.11.4)
       activesupport (>= 7.0.8)
       baran (~> 0.1.9)
       colorize (~> 1.1.0)

--- a/lib/langchain/version.rb
+++ b/lib/langchain/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Langchain
-  VERSION = "0.11.3"
+  VERSION = "0.11.4"
 end


### PR DESCRIPTION
Bump Release Version for 0.11.4

## [0.11.4] - 2024-04-19
- New `Langchain::LLM::AWSBedrock#chat()` to wrap Bedrock Claude requests
- New `Langchain::LLM::OllamaResponse#total_tokens()` method