### PR TITLE
Fix weather tool exceptions and units parameter

### DIFF
--- a/examples/assistant_chat.rb
+++ b/examples/assistant_chat.rb
@@ -6,32 +6,32 @@ require "reline"
 # gem install reline
 # or add `gem "reline"` to your Gemfile
 
-openai = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
-thread = Langchain::Thread.new
-assistant = Langchain::Assistant.new(
-  llm: openai,
-  thread: thread,
-  instructions: "You are a Meteorologist Assistant that is able to pull the weather for any location",
+@assistant = Langchain::Assistant.new(
+  llm: Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"]),
+  thread: Langchain::Thread.new,
+  instructions: "You are a Meteorologist Assistant that is able to pull the weather for any city in imperial units.",
   tools: [
     Langchain::Tool::Weather.new(api_key: ENV["OPEN_WEATHER_API_KEY"])
   ]
 )
 
-DONE = %w[done end eof exit].freeze
+DONE = %w[done end eof print exit].freeze
 
 puts "Welcome to your Meteorological assistant!"
 
 def prompt_for_message
-  puts "(multiline input; type 'end' on its own line when done. or exit to exit)"
+  puts "(multiline input; type 'end' on its own line when done. or 'print' to print thread, or 'exit' to exit)"
 
-  user_message = Reline.readmultiline("Question: ", true) do |multiline_input|
+  user_message = Reline.readmultiline("User message: ", true) do |multiline_input|
     last = multiline_input.split.last
     DONE.include?(last)
   end
 
   return :noop unless user_message
+  return :print if user_message == "print"
 
   lines = user_message.split("\n")
+
   if lines.size > 1 && DONE.include?(lines.last)
     # remove the "done" from the message
     user_message = lines[0..-2].join("\n")
@@ -42,6 +42,22 @@ def prompt_for_message
   user_message
 end
 
+def print_thread
+  @assistant.thread.messages.each do |message|
+    puts "----"
+    puts message.role + ": " + message.content
+    case message.role
+    when "assistant"
+      message.tool_calls.each do |tool_call|
+        puts " " + tool_call["function"]["name"] + ": " << tool_call["function"]["arguments"]
+      end
+    when "tool"
+      puts " " + message.tool_call_id
+    end
+  end
+  puts "---"
+end
+
 begin
   loop do
     user_message = prompt_for_message
@@ -49,12 +65,15 @@ begin
     case user_message
     when :noop
       next
+    when :print
+      print_thread
+      next
     when :exit
       break
     end
 
-    assistant.add_message_and_run content: user_message, auto_tool_execution: true
-    puts assistant.thread.messages.last.content
+    @assistant.add_message_and_run content: user_message, auto_tool_execution: true
+    puts @assistant.thread.messages.last.content
   end
 rescue Interrupt
   exit 0

--- a/lib/langchain/tool/weather/weather.json
+++ b/lib/langchain/tool/weather/weather.json
@@ -9,12 +9,12 @@
         "properties": {
           "city": {
             "type": "string",
-            "description": "city name"
+            "description": "City name, optional ISO 3166 state code (USA only), and optional ISO 3166 country code divided by comma."
           },
           "units": {
             "type": "string",
             "enum": ["standard", "metric", "imperial"],
-            "description": "units"
+            "description": "Units"
           }
         },
         "required": ["city"]

--- a/lib/langchain/tool/weather/weather.json
+++ b/lib/langchain/tool/weather/weather.json
@@ -2,17 +2,22 @@
   {
     "type": "function",
     "function": {
-      "name": "weather-execute",
-      "description": "Returns current weather for a city",
+      "name": "weather-current_weather",
+      "description": "Returns current weather for a city in the requested units",
       "parameters": {
         "type": "object",
         "properties": {
-          "input": {
+          "city": {
             "type": "string",
-            "description": "comma separated city and unit (optional: imperial, metric, or standard)"
+            "description": "city name"
+          },
+          "units": {
+            "type": "string",
+            "enum": ["standard", "metric", "imperial"],
+            "description": "units"
           }
         },
-        "required": ["input"]
+        "required": ["city"]
       }
     }
   }

--- a/lib/langchain/tool/weather/weather.rb
+++ b/lib/langchain/tool/weather/weather.rb
@@ -14,7 +14,11 @@ module Langchain::Tool
     #
     # Usage:
     #     weather = Langchain::Tool::Weather.new(api_key: ENV["OPEN_WEATHER_API_KEY"])
-    #     weather.current_weather(city: "Los Angeles", units: "imperial")
+    #
+    #     # Examples:
+    #     weather.current_weather(city: "Boston")
+    #     weather.current_weather(city: "Los Angeles, CA", units: "imperial")
+    #     weather.current_weather(city: "Rome, IT", units: "metric")
     #
     NAME = "weather"
     ANNOTATIONS_PATH = Langchain.root.join("./langchain/tool/#{NAME}/#{NAME}.json").to_path
@@ -37,7 +41,7 @@ module Langchain::Tool
     end
 
     # Returns current weather for a city
-    # @param city [String] City name
+    # @param city [String] City name, optional ISO 3166 state code (USA only), and optional ISO 3166 country code divided by comma.
     # @param units [String] Units for response. One of "standard", "metric", or "imperial".
     # @return [String] Description of the weather
     def current_weather(city:, units: "standard")

--- a/spec/langchain/tool/weather_spec.rb
+++ b/spec/langchain/tool/weather_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe Langchain::Tool::Weather do
 
   describe "#execute" do
     it "returns current weather" do
-      expect(subject.execute(input: "Boston; standard")).to include("282.57")
+      expect(subject.current_weather(city: "Boston")).to include("282.57")
     end
 
     it "returns current weather with units" do
-      expect(subject.execute(input: "Chicago; imperial")).to include("88.56")
+      expect(subject.current_weather(city: "Chicago", units: "imperial")).to include("88.56")
     end
   end
 end

--- a/spec/langchain/tool/weather_spec.rb
+++ b/spec/langchain/tool/weather_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Langchain::Tool::Weather do
 
   let(:response_farenheit) {
     OpenWeather::Models::City::Weather.new(
-      name: "Chicago",
+      name: "Chicago, IL",
       dt: Time.now,
       main: {
         feels_like: 85.12,
@@ -43,7 +43,7 @@ RSpec.describe Langchain::Tool::Weather do
       .and_return(response)
 
     allow(subject.client).to receive(:current_weather)
-      .with(city: "Chicago", units: "imperial")
+      .with(city: "Chicago, IL", units: "imperial")
       .and_return(response_farenheit)
   end
 
@@ -53,7 +53,7 @@ RSpec.describe Langchain::Tool::Weather do
     end
 
     it "returns current weather with units" do
-      expect(subject.current_weather(city: "Chicago", units: "imperial")).to include("88.56")
+      expect(subject.current_weather(city: "Chicago, IL", units: "imperial")).to include("88.56")
     end
   end
 end


### PR DESCRIPTION
Fixes #175 and replaces PR #193.

- Catching the exception is still necessary since api errors still occur, and this allows llm to retry.
- We could also consider having `current_weather` return an array instead of string, but the string works well.