### PR TITLE
ollama raw_response is parsed JSON, so expect a Hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /spec/reports/
 /tmp/
 /.vscode/
+/TAGS
 
 # rspec failure tracking
 .rspec_status

--- a/lib/langchain/llm/response/ollama_response.rb
+++ b/lib/langchain/llm/response/ollama_response.rb
@@ -13,6 +13,10 @@ module Langchain::LLM
       end
     end
 
+    def chat_completions
+      [raw_response]
+    end
+
     def chat_completion
       raw_response.dig("message", "content")
     end

--- a/lib/langchain/llm/response/ollama_response.rb
+++ b/lib/langchain/llm/response/ollama_response.rb
@@ -22,7 +22,14 @@ module Langchain::LLM
     end
 
     def completions
-      raw_response.is_a?(String) ? [raw_response] : []
+      if raw_response.is_a?(String)
+        [{"message" => raw_response}]
+      elsif raw_response.is_a?(Hash)
+        [raw_response]
+      else
+        warn "[ollama] Unexpected response type: #{raw_response.class}"
+        []
+      end
     end
 
     def embedding

--- a/spec/langchain/llm/ollama_spec.rb
+++ b/spec/langchain/llm/ollama_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe Langchain::LLM::Ollama do
       expect(response.completion.dig("message")).to be_a(Hash)
       expect(response.completion.dig("message", "role")).to eq("assistant")
       expect(response.completion.dig("message", "content").strip).to start_with("Of course, I'd be happy")
+
+      expect(response.chat_completions).to be_a(Array)
+      expect(response.chat_completions.first).to be_a(Hash)
+      expect(response.chat_completions.first.dig("message")).to be_a(Hash)
+      expect(response.chat_completions.first.dig("message", "role")).to eq("assistant")
+      expect(response.chat_completions.first.dig("message", "content").strip).to start_with("Of course, I'd be happy")
     end
   end
 

--- a/spec/langchain/llm/ollama_spec.rb
+++ b/spec/langchain/llm/ollama_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Langchain::LLM::Ollama do
       response = subject.complete(prompt: "In one word, life is ")
 
       expect(response).to be_a(Langchain::LLM::OllamaResponse)
-      expect(response.completion).to eq("fragile.")
+      message = {"message" => "fragile."}
+      expect(response.completion).to eq(message)
     end
   end
 
@@ -56,6 +57,12 @@ RSpec.describe Langchain::LLM::Ollama do
 
       expect(response).to be_a(Langchain::LLM::OllamaResponse)
       expect(response.chat_completion).to eq(fixture.dig("message", "content"))
+
+      expect(response.completions).to be_a(Array)
+      expect(response.completion).to be_a(Hash)
+      expect(response.completion.dig("message")).to be_a(Hash)
+      expect(response.completion.dig("message", "role")).to eq("assistant")
+      expect(response.completion.dig("message", "content").strip).to start_with("Of course, I'd be happy")
     end
   end
 
@@ -68,8 +75,8 @@ RSpec.describe Langchain::LLM::Ollama do
       response = subject.summarize(text: mary_had_a_little_lamb_text)
 
       expect(response).to be_a(Langchain::LLM::OllamaResponse)
-      expect(response.completion).not_to match(/summary/)
-      expect(response.completion).to start_with("A little lamb follows Mary everywhere she goes")
+      expect(response.completion).to be_a(Hash)
+      expect(response.completion["message"]).to start_with("A little lamb follows Mary everywhere she goes")
     end
   end
 


### PR DESCRIPTION
The previous expectation of a String has been kept; but unsure when this appears

Now, afaict, ollama response for chat is `{message: {role:, content:}}`

An example raw_response:

```ruby
{"model"=>"llama3",
  "created_at"=>"2024-05-07T11:55:32.552608Z",
  "message"=>{"role"=>"assistant", "content"=>"The answer to 2+2 is... 4!"},
  "done"=>true,
  "total_duration"=>4773981125,
  "load_duration"=>3639324792,
  "prompt_eval_count"=>30,
  "prompt_eval_duration"=>262419000,
  "eval_count"=>13,
  "eval_duration"=>867458000}
```