### PR TITLE
Langchain::LLM::Anthropic#complete() method uses claude-2.1 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 - Langchain::LLM::Ollama now uses `llama3` by default
+- Langchain::LLM::Anthropic#complete() now uses `claude-2.1` by default
 
 ## [0.12.0] - 2024-04-22
 - [BREAKING] Rename `dimension` parameter to `dimensions` everywhere

--- a/lib/langchain/llm/anthropic.rb
+++ b/lib/langchain/llm/anthropic.rb
@@ -13,7 +13,7 @@ module Langchain::LLM
   class Anthropic < Base
     DEFAULTS = {
       temperature: 0.0,
-      completion_model_name: "claude-2",
+      completion_model_name: "claude-2.1",
       chat_completion_model_name: "claude-3-sonnet-20240229",
       max_tokens_to_sample: 256
     }.freeze
@@ -72,9 +72,6 @@ module Langchain::LLM
       parameters[:metadata] = metadata if metadata
       parameters[:stream] = stream if stream
 
-      # TODO: Implement token length validator for Anthropic
-      # parameters[:max_tokens_to_sample] = validate_max_tokens(prompt, parameters[:completion_model_name])
-
       response = client.complete(parameters: parameters)
       Langchain::LLM::AnthropicResponse.new(response)
     end
@@ -128,10 +125,5 @@ module Langchain::LLM
 
       Langchain::LLM::AnthropicResponse.new(response)
     end
-
-    # TODO: Implement token length validator for Anthropic
-    # def validate_max_tokens(messages, model)
-    #   LENGTH_VALIDATOR.validate_max_tokens!(messages, model)
-    # end
   end
 end

--- a/spec/fixtures/llm/anthropic/complete.json
+++ b/spec/fixtures/llm/anthropic/complete.json
@@ -1,7 +1,7 @@
 {
   "completion": " The sky has no definitive",
   "stop_reason": "max_tokens",
-  "model": "claude-2.0",
+  "model": "claude-2.1",
   "stop": null,
   "log_id": "b5a12f0ec9900c47ed5c9254d2794f72c14afa6c61571a11ce33f45034ae7bce"
 }

--- a/spec/langchain/llm/anthropic_spec.rb
+++ b/spec/langchain/llm/anthropic_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Langchain::LLM::Anthropic do
       it "returns a completion" do
         expect(subject.complete(prompt: completion).completion).to eq(" The sky has no definitive")
       end
+
+      it "returns model attribute" do
+        expect(subject.complete(prompt: completion).model).to eq("claude-2.1")
+      end
     end
   end
 
@@ -47,6 +51,10 @@ RSpec.describe Langchain::LLM::Anthropic do
 
       it "returns a completion" do
         expect(subject.chat(messages: messages).chat_completion).to eq("The sky doesn't have a defined height or upper limit.")
+      end
+
+      it "returns model attribute" do
+        expect(subject.chat(messages: messages).model).to eq("claude-3-sonnet-20240229")
       end
     end
   end


### PR DESCRIPTION
Use `claude-2.1` by default as it is most powerful model that still support the `/complete` endpoint.