### PR TITLE
Handle missing verdicts in Faithfulness eval

### DIFF
--- a/lib/langchain/evals/ragas/faithfulness.rb
+++ b/lib/langchain/evals/ragas/faithfulness.rb
@@ -42,6 +42,8 @@ module Langchain
 
         def count_verified_statements(verifications)
           match = verifications.match(/Final verdict for each statement in order:\s*(.*)/)
+          return 0.0 unless match # no verified statements found
+
           verdicts = match.captures.first
           verdicts
             .split(".")

--- a/spec/langchain/evals/ragas/faithfulness_spec.rb
+++ b/spec/langchain/evals/ragas/faithfulness_spec.rb
@@ -20,5 +20,15 @@ RSpec.describe Langchain::Evals::Ragas::Faithfulness do
     it "generates the faithfulness score" do
       expect(subject.score(question: question, answer: answer, context: context)).to eq(0.5)
     end
+
+    context "when no verified statements are found" do
+      before do
+        allow(subject).to receive(:statements_verification).and_return("No verified statements found.")
+      end
+
+      it "returns a faithfulness score of 0" do
+        expect(subject.score(question: question, answer: answer, context: context)).to eq(0.0)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description:
The `count_verified_statements` method currently fails with an [undefined method 'captures' for nil](https://github.com/patterns-ai-core/langchainrb/blob/2fb2c1f85f4ae8cf023fc673b1253b7a28934076/lib/langchain/evals/ragas/faithfulness.rb#L45) error when the expected string "Final verdict for each statement in order:" is absent from the LLMs response. This typically occurs if the provided context is either blank or not relevant to the question/answer.

### Proposed Change:
This pull request introduces a guard clause in the `count_verified_statements` method to handle cases where the LLMs output does not contain the expected verdict format. I think returning a score of `0.0` makes sense given that this would be the correct score in most of these failure cases.

### Code Changes:
- A conditional check is added to return `0.0` immediately if no match is found in the verifications string.