### PR TITLE
Adding GCP scope to auth in google_vertex_ai.rb

### DIFF
--- a/lib/langchain/llm/google_vertex_ai.rb
+++ b/lib/langchain/llm/google_vertex_ai.rb
@@ -28,7 +28,10 @@ module Langchain::LLM
     def initialize(project_id:, region:, default_options: {})
       depends_on "googleauth"
 
-      @authorizer = ::Google::Auth.get_application_default(scope: 'https://www.googleapis.com/auth/cloud-platform')
+      @authorizer = ::Google::Auth.get_application_default(scope: [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/generative-language.retriever"
+      ])
       proj_id = project_id || @authorizer.project_id || @authorizer.quota_project_id
       @url = "https://#{region}-aiplatform.googleapis.com/v1/projects/#{proj_id}/locations/#{region}/publishers/google/models/"
 

--- a/lib/langchain/llm/google_vertex_ai.rb
+++ b/lib/langchain/llm/google_vertex_ai.rb
@@ -28,7 +28,7 @@ module Langchain::LLM
     def initialize(project_id:, region:, default_options: {})
       depends_on "googleauth"
 
-      @authorizer = ::Google::Auth.get_application_default
+      @authorizer = ::Google::Auth.get_application_default(scope: 'https://www.googleapis.com/auth/cloud-platform')
       proj_id = project_id || @authorizer.project_id || @authorizer.quota_project_id
       @url = "https://#{region}-aiplatform.googleapis.com/v1/projects/#{proj_id}/locations/#{region}/publishers/google/models/"
 


### PR DESCRIPTION
adding scope as it often gives me error. See  issue #622 

(https://github.com/patterns-ai-core/langchainrb/issues/622)

Error being fixed:

```
 VertexLLM.authorizer.fetch_access_token
(irb):1:in `<main>': Authorization failed.  Server message: (Signet::AuthorizationError)
{"error":"invalid_scope","error_description":"Invalid OAuth scope or ID token audience provided."}
```