### PR TITLE
fix tool use inputs when streaming aws bedrock

### DIFF
--- a/spec/langchain/llm/aws_bedrock_spec.rb
+++ b/spec/langchain/llm/aws_bedrock_spec.rb
@@ -572,6 +572,46 @@ RSpec.describe Langchain::LLM::AwsBedrock do
           "usage" => {"input_tokens" => 17, "output_tokens" => 20}
         })
       end
+
+      context "with input json deltas" do
+        let(:chunks) do
+          [
+            {"type" => "message_start", "message" => {"id" => "msg_abcdefg", "type" => "message", "role" => "assistant", "content" => [], "model" => "anthropic.claude-3-sonnet-20240229-v1:0", "stop_reason" => nil, "stop_sequence" => nil, "usage" => {"input_tokens" => 17, "output_tokens" => 1}}},
+            {"type" => "content_block_start", "index" => 0, "content_block" => {"type" => "text", "text" => ""}},
+            {"type" => "content_block_delta", "index" => 0, "delta" => {"type" => "text_delta", "text" => "The"}},
+            {"type" => "content_block_delta", "index" => 0, "delta" => {"type" => "text_delta", "text" => " capital of France"}},
+            {"type" => "content_block_delta", "index" => 0, "delta" => {"type" => "text_delta", "text" => " is Paris."}},
+            {"type" => "content_block_stop", "index" => 0},
+            {"type" => "content_block_start", "index" => 1, "content_block" => {"type" => "tool_use", "id" => "toolu_abc", "name" => "population", "input" => {}}},
+            {"type" => "content_block_delta", "index" => 1, "delta" => {"type" => "input_json_delta", "partial_json" => ""}},
+            {"type" => "content_block_delta", "index" => 1, "delta" => {"type" => "input_json_delta", "partial_json" => "{\"ci"}},
+            {"type" => "content_block_delta", "index" => 1, "delta" => {"type" => "input_json_delta", "partial_json" => "ty\": \"Pari"}},
+            {"type" => "content_block_delta", "index" => 1, "delta" => {"type" => "input_json_delta", "partial_json" => "s\", \"countr"}},
+            {"type" => "content_block_delta", "index" => 1, "delta" => {"type" => "input_json_delta", "partial_json" => "y\""}},
+            {"type" => "content_block_delta", "index" => 1, "delta" => {"type" => "input_json_delta", "partial_json" => ": \"France\"}"}},
+            {"type" => "message_delta", "delta" => {"stop_reason" => "end_turn", "stop_sequence" => nil}, "usage" => {"output_tokens" => 20}},
+            {"type" => "message_stop", "amazon-bedrock-invocationMetrics" => {"inputTokenCount" => 17, "outputTokenCount" => 20, "invocationLatency" => 1234, "firstByteLatency" => 567}}
+          ]
+        end
+
+        it "returns the correct raw response" do
+          response = subject.send(:response_from_chunks, chunks)
+
+          expect(response.raw_response).to eq({
+            "id" => "msg_abcdefg",
+            "type" => "message",
+            "role" => "assistant",
+            "content" => [
+              {"type" => "text", "text" => "The capital of France is Paris."},
+              {"type" => "tool_use", "id" => "toolu_abc", "name" => "population", "input" => {"city" => "Paris", "country" => "France"}}
+            ],
+            "model" => "anthropic.claude-3-sonnet-20240229-v1:0",
+            "stop_reason" => "end_turn",
+            "stop_sequence" => nil,
+            "usage" => {"input_tokens" => 17, "output_tokens" => 20}
+          })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When using streaming with AWS Bedrock we build the response from the chunks. I had only considered text deltas when building this. In this PR I also include input JSON deltas.

![image](https://github.com/patterns-ai-core/langchainrb/assets/57372662/61799bee-1646-4409-af24-390826d895d7)
