### PR TITLE
accept non ascii url

### DIFF
--- a/lib/langchain/loader.rb
+++ b/lib/langchain/loader.rb
@@ -90,7 +90,7 @@ module Langchain
     private
 
     def load_from_url
-      URI.parse(@path).open
+      URI.parse(URI::DEFAULT_PARSER.escape(@path)).open
     end
 
     def load_from_path

--- a/spec/langchain/loader_spec.rb
+++ b/spec/langchain/loader_spec.rb
@@ -362,5 +362,11 @@ RSpec.describe Langchain::Loader do
 
       it { expect(subject).to be_truthy }
     end
+
+    context "with non ASCII chars URL" do
+      let(:path) { "https://exmaple.com/méxico" }
+
+      it { expect(subject).to be_truthy }
+    end
   end
 end


### PR DESCRIPTION
for some url like `"https://vadb.org/events/d/México"` the url will not work, with this change , it will