### PR TITLE
Update URL to CHANGELOG

### DIFF
--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/andreibondarev/langchainrb"
-  spec.metadata["changelog_uri"] = "https://github.com/andreibondarev/langchainrb/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/patterns-ai-core/langchainrb"
+  spec.metadata["changelog_uri"] = "https://github.com/patterns-ai-core/langchainrb/blob/main/CHANGELOG.md"
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/langchainrb"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
This updates the links shown on https://rubygems.org/gems/langchainrb as the ones before did not work / redirect.
