### PR TITLE
Update loader.rb

### DIFF
--- a/lib/langchain/loader.rb
+++ b/lib/langchain/loader.rb
@@ -90,7 +90,9 @@ module Langchain
     private
 
     def load_from_url
-      URI.parse(URI::DEFAULT_PARSER.escape(@path)).open
+      unescaped_url = URI.decode_www_form_component(@path)
+      escaped_url = URI::DEFAULT_PARSER.escape(unescaped_url)
+      URI.parse(escaped_url).open
     end
 
     def load_from_path


### PR DESCRIPTION
The URI::DEFAULT_PARSER.escape method escapes a string so that it is safe to use as a URL, but it doesn't handle URLs that are already percent-encoded or have special characters.

This PR makes it possible to unescape the URL and then use URI::DEFAULT_PARSER.escape. However, it's generally better to handle URLs using a library designed for such tasks, like Addressable::URI.