### PR TITLE
State machine for Assistant's execution phases

### DIFF
--- a/lib/langchain/assistants/assistant.rb
+++ b/lib/langchain/assistants/assistant.rb
@@ -229,18 +229,16 @@ module Langchain
     #
     # @return [Symbol] The next state
     def execute_tools
-      begin
-        # TODO: Should we create a method parameter to let the user change the value of the tool timeout?
-        Timeout.timeout(600) { run_tools(thread.messages.last.tool_calls) }
-        :in_progress
-      rescue Timeout::Error
-        # If the tool output is not provided within 10 minutes the run will transition to an expired status
-        Langchain.logger.error("Running tools timed out")
-        :expired
-      rescue StandardError => e
-        Langchain.logger.error("Error running tools: #{e.message}")
-        :failed
-      end
+      # TODO: Should we create a method parameter to let the user change the value of the tool timeout?
+      Timeout.timeout(600) { run_tools(thread.messages.last.tool_calls) }
+      :in_progress
+    rescue Timeout::Error
+      # If the tool output is not provided within 10 minutes the run will transition to an expired status
+      Langchain.logger.error("Running tools timed out")
+      :expired
+    rescue => e
+      Langchain.logger.error("Error running tools: #{e.message}")
+      :failed
     end
 
     # Determine the tool role based on the LLM type

--- a/lib/langchain/assistants/messages/base.rb
+++ b/lib/langchain/assistants/messages/base.rb
@@ -7,9 +7,43 @@ module Langchain
 
       # Check if the message came from a user
       #
-      # @param [Boolean] true/false whether the message came from a user
+      # @return [Boolean] true/false whether the message came from a user
       def user?
         role == "user"
+      end
+
+      # Check if the message came from an LLM
+      #
+      # @raise NotImplementedError if the subclass does not implement this method
+      def llm?
+        raise NotImplementedError, "Class #{self.class.name} must implement the method 'llm?'"
+      end
+
+      # Check if the message is a tool call
+      #
+      # @raise NotImplementedError if the subclass does not implement this method
+      def tool?
+        raise NotImplementedError, "Class #{self.class.name} must implement the method 'tool?'"
+      end
+
+      # Check if the message is a system prompt
+      #
+      # @raise NotImplementedError if the subclass does not implement this method
+      def system?
+        raise NotImplementedError, "Class #{self.class.name} must implement the method 'system?'"
+      end
+
+      # Returns the standardized role symbol based on the specific role methods
+      #
+      # @return [Symbol] the standardized role symbol (:system, :llm, :tool, :user, or :unknown)
+      def standard_role
+        return :user if user?
+        return :llm if llm?
+        return :tool if tool?
+        return :system if system?
+
+        # TODO: Should we return :unknown or raise an error?
+        :unknown
       end
     end
   end


### PR DESCRIPTION
### Issue #566

This pull request introduces a simplified state machine for managing the Assistant's execution phases. Inspired by the [OpenAI Assistants](https://platform.openai.com/docs/assistants/how-it-works/runs-and-run-steps) model, this leaner approach enhances code readability and simplifies debugging.

**Changes**:
- [x] Introduced state management within the run method with possible states: `in_progress`, `running_tools`, `completed`, `failed`, and `expired`.
- [x] Refactored code into distinct methods following the Single Responsibility Principle (SRP), enhancing readability and ease of debugging.
- [x] Used `case` statements for state management to improve code clarity and avoid nested `if` statements.
- [x] Created a `standard_role` method for consistent message type handling across different LLMs, enabling `case` statements in `process_latest_message` to manage the execution flow based on the role of the last message.
- [x] Incorporated an `expired` status similar to OpenAI, transitioning to expired if tool output is not provided within 10 minutes to prevent application hang.
- [x] Fixed an issue where the content of a message was not included if the LLM responded with one or more tool calls.

**About implementation**:

After analyzing OpenAI's approach, I believe a specialized state machine gem is over-engineered for our needs. OpenAI initializes a thread and creates a job for each run, allowing state access during execution, which is ideal for asynchronous processing. In our synchronous context, a simpler state machine within the run method is sufficient, reducing complexity while maintaining clear state management.

**Notes**:

I have left several TODO notes in the code for further improvements and would appreciate your feedback on these points. I am open to discussing the implementation and any potential improvements you might suggest. Thank you!