### PR TITLE
Issue 697 - Show API error when calling `.complete` on Anthropic client

### DIFF
--- a/lib/langchain/llm/base.rb
+++ b/lib/langchain/llm/base.rb
@@ -8,6 +8,7 @@ module Langchain::LLM
   # Langchain.rb provides a common interface to interact with all supported LLMs:
   #
   # - {Langchain::LLM::AI21}
+  # - {Langchain::LLM::Anthropic}
   # - {Langchain::LLM::Azure}
   # - {Langchain::LLM::Cohere}
   # - {Langchain::LLM::GooglePalm}

--- a/spec/fixtures/llm/anthropic/error.json
+++ b/spec/fixtures/llm/anthropic/error.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "error": {
+    "type": "invalid_request_error",
+    "message": "The request is invalid. Please check the request and try again."
+  }
+}

--- a/spec/langchain/llm/anthropic_spec.rb
+++ b/spec/langchain/llm/anthropic_spec.rb
@@ -30,6 +30,25 @@ RSpec.describe Langchain::LLM::Anthropic do
         expect(subject.complete(prompt: completion).model).to eq("claude-2.1")
       end
     end
+
+    context "with failed API call" do
+      let(:fixture) { File.read("spec/fixtures/llm/anthropic/error.json") }
+
+      before do
+        allow(subject.client).to receive(:complete)
+          .with(parameters: {
+            model: described_class::DEFAULTS[:completion_model_name],
+            prompt: completion,
+            temperature: described_class::DEFAULTS[:temperature],
+            max_tokens_to_sample: described_class::DEFAULTS[:max_tokens_to_sample]
+          })
+          .and_return(JSON.parse(fixture))
+      end
+
+      it "raises an error" do
+        expect { subject.complete(prompt: completion) }.to raise_error(Langchain::LLM::ApiError, "Anthropic API error: The request is invalid. Please check the request and try again.")
+      end
+    end
   end
 
   describe "#chat" do


### PR DESCRIPTION
Fixes issue #697 


Before:
![image](https://github.com/patterns-ai-core/langchainrb/assets/65372461/e0316321-eb99-4960-8163-6c1b0a799aad)


After:
![image](https://github.com/patterns-ai-core/langchainrb/assets/65372461/1646d1bb-19fd-468e-b1fa-2b4887aeb8b9)
