### PR TITLE
Update default chat completions model to gpt-4o-mini

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -16,7 +16,7 @@ module Langchain::LLM
     DEFAULTS = {
       n: 1,
       temperature: 0.0,
-      chat_completion_model_name: "gpt-3.5-turbo",
+      chat_completion_model_name: "gpt-4o-mini",
       embeddings_model_name: "text-embedding-3-small"
     }.freeze
 

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -204,10 +204,10 @@ RSpec.describe Langchain::LLM::OpenAI do
   describe "#complete" do
     let(:response) do
       {
-        "id" => "cmpl-7BZg4cP5xzga4IyLI6u97WMepAJj2",
+        "id" => "chatcmpl-9orgr5hNUdCsQeNWGnmNnbXQVIcPN",
         "object" => "chat.completion",
-        "created" => 1682993108,
-        "model" => "gpt-3.5-turbo",
+        "created" => 1721906887,
+        "model" => "gpt-4o-mini-2024-07-18",
         "choices" => [
           {
             "message" => {
@@ -236,7 +236,7 @@ RSpec.describe Langchain::LLM::OpenAI do
         {
           parameters: {
             n: 1,
-            model: "gpt-3.5-turbo",
+            model: "gpt-4o-mini",
             messages: [{content: "Hello World", role: "user"}],
             temperature: 0.0
             # max_tokens: 4087
@@ -248,7 +248,7 @@ RSpec.describe Langchain::LLM::OpenAI do
         response = subject.complete(prompt: "Hello World")
 
         expect(response).to be_a(Langchain::LLM::OpenAIResponse)
-        expect(response.model).to eq("gpt-3.5-turbo")
+        expect(response.model).to eq("gpt-4o-mini-2024-07-18")
         expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
         expect(response.prompt_tokens).to eq(7)
         expect(response.completion_tokens).to eq(16)
@@ -259,7 +259,7 @@ RSpec.describe Langchain::LLM::OpenAI do
         response = subject.complete(prompt: "Hello World")
 
         expect(response).to be_a(Langchain::LLM::OpenAIResponse)
-        expect(response.model).to eq("gpt-3.5-turbo")
+        expect(response.model).to eq("gpt-4o-mini-2024-07-18")
         expect(response.completions).to eq([{"message" => {"role" => "assistant", "content" => "The meaning of life is subjective and can vary from person to person."}, "finish_reason" => "stop", "index" => 0}])
         expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
       end
@@ -297,7 +297,7 @@ RSpec.describe Langchain::LLM::OpenAI do
             parameters: {
               n: 1,
               # max_tokens: 4087,
-              model: "gpt-3.5-turbo",
+              model: "gpt-4o-mini",
               messages: [{content: "Hello World", role: "user"}],
               temperature: 0.0
             }
@@ -331,7 +331,7 @@ RSpec.describe Langchain::LLM::OpenAI do
             parameters: {
               n: 1,
               # max_tokens: 4087 ,
-              model: "gpt-3.5-turbo",
+              model: "gpt-4o-mini",
               messages: [{content: "Hello World", role: "user"}],
               temperature: 0.0
             }
@@ -355,7 +355,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with failed API call" do
       let(:parameters) do
-        {parameters: {n: 1, model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 0.0}} # , max_tokens: 4087}}
+        {parameters: {n: 1, model: "gpt-4o-mini", messages: [{content: "Hello World", role: "user"}], temperature: 0.0}} # , max_tokens: 4087}}
       end
       let(:response) do
         {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
@@ -390,7 +390,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
   describe "#chat" do
     let(:prompt) { "What is the meaning of life?" }
-    let(:model) { "gpt-3.5-turbo" }
+    let(:model) { "gpt-4o-mini" }
     let(:temperature) { 0.0 }
     let(:n) { 1 }
     let(:history) { [content: prompt, role: "user"] }
@@ -411,10 +411,10 @@ RSpec.describe Langchain::LLM::OpenAI do
     end
     let(:response) do
       {
-        "id" => "chatcmpl-7Hcl1sXOtsaUBKJGGhNujEIwhauaD",
+        "id" => "chatcmpl-9otuxUHnW84Zqu97VE1eKPmXVLAv0",
         "object" => "chat.completion",
-        "created" => 1684434915,
-        "model" => model,
+        "created" => 1721918375,
+        "model" => "gpt-4o-mini-2024-07-18",
         "usage" => {
           "prompt_tokens" => 14,
           "completion_tokens" => 25,
@@ -428,7 +428,7 @@ RSpec.describe Langchain::LLM::OpenAI do
       allow(subject.client).to receive(:chat).with(parameters).and_return(response)
     end
 
-    it "ignores any invalid parameters provided" do
+    it "ignoresq any invalid parameters provided" do
       response = subject.chat(
         messages: [{role: "user", content: "What is the meaning of life?"}],
         top_k: 5,
@@ -442,7 +442,7 @@ RSpec.describe Langchain::LLM::OpenAI do
       response = subject.chat(messages: [{role: "user", content: "What is the meaning of life?"}])
 
       expect(response).to be_a(Langchain::LLM::OpenAIResponse)
-      expect(response.model).to eq("gpt-3.5-turbo")
+      expect(response.model).to eq("gpt-4o-mini-2024-07-18")
       expect(response.chat_completion).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
       expect(response.prompt_tokens).to eq(14)
       expect(response.completion_tokens).to eq(25)
@@ -454,7 +454,7 @@ RSpec.describe Langchain::LLM::OpenAI do
         response = subject.chat(messages: [{role: "user", content: prompt}])
 
         expect(response).to be_a(Langchain::LLM::OpenAIResponse)
-        expect(response.model).to eq(model)
+        expect(response.model).to eq("gpt-4o-mini-2024-07-18")
         expect(response.completions).to eq(choices)
         expect(response.chat_completion).to eq(answer)
       end


### PR DESCRIPTION
This PR updates the default chat completions model to `gpt-4o-mini` as per [Open AI doc](https://platform.openai.com/docs/models/gpt-3-5-turbo)