### PR TITLE
Send nonCamelCased tools params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 .DS_Store
 .idea
 test.ann
+.byebug_history

--- a/lib/langchain/llm/google_gemini.rb
+++ b/lib/langchain/llm/google_gemini.rb
@@ -10,7 +10,7 @@ module Langchain::LLM
       temperature: 0.0
     }
 
-    attr_reader :defaults, :api_key
+    attr_reader :defaults, :api_key, :model
 
     def initialize(api_key:, default_options: {})
       @api_key = api_key
@@ -27,6 +27,7 @@ module Langchain::LLM
         system: :system_instruction,
         tool_choice: :tool_config
       )
+      @model = @defaults[:chat_completion_model_name]
     end
 
     # Generate a chat completion for a given prompt
@@ -58,7 +59,7 @@ module Langchain::LLM
       parameters[:generation_config][:stop_sequences] ||= parameters[:stop] if parameters[:stop]
       parameters.delete(:stop)
 
-      uri = URI("https://generativelanguage.googleapis.com/v1beta/models/#{parameters[:model]}:generateContent?key=#{api_key}")
+      uri = URI("https://generativelanguage.googleapis.com/v1beta/models/#{model}:generateContent?key=#{api_key}")
 
       request = Net::HTTP::Post.new(uri)
       request.content_type = "application/json"
@@ -69,8 +70,7 @@ module Langchain::LLM
       end
 
       parsed_response = JSON.parse(response.body)
-
-      wrapped_response = Langchain::LLM::GoogleGeminiResponse.new(parsed_response, model: parameters[:model])
+      wrapped_response = Langchain::LLM::GoogleGeminiResponse.new(parsed_response, model: model)
 
       if wrapped_response.chat_completion || Array(wrapped_response.tool_calls).any?
         wrapped_response

--- a/lib/langchain/llm/google_gemini.rb
+++ b/lib/langchain/llm/google_gemini.rb
@@ -112,7 +112,15 @@ module Langchain::LLM
       parameters[:generation_config][:stop_sequences] ||= parameters[:stop] if parameters[:stop]
       parameters.delete(:stop)
 
-      Langchain::Utils::HashTransformer.deep_transform_keys(parameters) { |key| Langchain::Utils::HashTransformer.camelize_lower(key.to_s).to_sym }
+      cached_tools = parameters.dig(:tools, :function_declarations) || []
+
+      formatted_gemini_params = Langchain::Utils::HashTransformer.deep_transform_keys(parameters) { |key| Langchain::Utils::HashTransformer.camelize_lower(key.to_s).to_sym }
+
+      if formatted_gemini_params[:tools]
+        formatted_gemini_params[:tools][:functionDeclarations] = cached_tools
+      end
+
+      formatted_gemini_params
     end
   end
 end


### PR DESCRIPTION
Google Gemini or better say news_retriever tool didn't work due to the updates in the list of arguments. See the error message:

```
E, [2024-07-30T08:05:04.021082 #6] ERROR -- : [Langchain.rb] Error running tools: unknown keyword: :sortBy; /usr/src/app/lib/langchain/tool/news_retriever.rb:61:in
```