### PR TITLE
fix: Langchain::Prompt::PromptTemplate#format with nested json

### DIFF
--- a/lib/langchain/prompt/base.rb
+++ b/lib/langchain/prompt/base.rb
@@ -83,11 +83,13 @@ module Langchain::Prompt
     #
     def self.extract_variables_from_template(template)
       input_variables = []
-      scanner = StringScanner.new(template)
 
-      while scanner.scan_until(/\{([^}]*)\}/)
+      template_without_consecutive_braces = template.gsub(/\{\{([^{}]*)\}\}/, "")
+      scanner = StringScanner.new(template_without_consecutive_braces)
+
+      while scanner.scan_until(/\{([a-z_][a-zA-Z0-9_]*)\}/)
         variable = scanner[1].strip
-        input_variables << variable unless variable.empty? || variable[0] == "{"
+        input_variables << variable
       end
 
       input_variables

--- a/lib/langchain/prompt/prompt_template.rb
+++ b/lib/langchain/prompt/prompt_template.rb
@@ -59,7 +59,7 @@ module Langchain::Prompt
     def format(**kwargs)
       result = @template
       kwargs.each { |key, value| result = result.gsub(/\{#{key}\}/, value.to_s) }
-      result.gsub(/{{/, "{").gsub(/}}/, "}")
+      result.gsub(/\{\{([^{}]*)\}\}/, '{\1}')
     end
 
     #

--- a/spec/langchain/prompts/base_spec.rb
+++ b/spec/langchain/prompts/base_spec.rb
@@ -59,17 +59,19 @@ RSpec.describe Langchain::Prompt::Base do
   end
 
   describe "#extract_variables_from_template" do
-    let(:basic_template) { "Tell me a {adjective} joke." }
-    let(:escaped_template) { "Tell me a {adjective} joke. Return in JSON in the format {{joke: 'The joke'}}" }
-
     it "extracts variables" do
-      input_variables = described_class.extract_variables_from_template(basic_template)
+      input_variables = described_class.extract_variables_from_template("Tell me a {adjective} joke.")
       expect(input_variables).to eq(%w[adjective])
     end
 
     it "excludes double curly brace variables" do
-      input_variables = described_class.extract_variables_from_template(escaped_template)
+      input_variables = described_class.extract_variables_from_template("Tell me a {adjective} joke. Return in JSON in the format {{joke: 'The joke'}}")
       expect(input_variables).to eq(%w[adjective])
+    end
+
+    it "ignores json objects" do
+      input_variables = described_class.extract_variables_from_template("This is a json object: {\"phone\":{\"number\":100}}")
+      expect(input_variables).to eq([])
     end
   end
 end

--- a/spec/langchain/prompts/prompt_template_spec.rb
+++ b/spec/langchain/prompts/prompt_template_spec.rb
@@ -64,6 +64,23 @@ RSpec.describe Langchain::Prompt::PromptTemplate do
 
       expect(prompt.format(adjective: "funny", content: "chickens")).to eq("Tell me a funny joke about chickens.")
     end
+
+    it "replaces <code>{{}}</code> with <code>{}</code>" do
+      prompt = described_class.new(
+        template: "This is a {{test}} case.",
+        input_variables: []
+      )
+
+      expect(prompt.format).to eq("This is a {test} case.")
+    end
+
+    it "ignores json objects in the template" do
+      prompt = described_class.new(
+        template: "This is a json object: {\"phone\":{\"number\":100}}",
+        input_variables: []
+      )
+      expect(prompt.format).to eq("This is a json object: {\"phone\":{\"number\":100}}")
+    end
   end
 
   describe "#from_template" do

--- a/spec/langchain/prompts/prompt_template_spec.rb
+++ b/spec/langchain/prompts/prompt_template_spec.rb
@@ -76,10 +76,10 @@ RSpec.describe Langchain::Prompt::PromptTemplate do
 
     it "ignores json objects in the template" do
       prompt = described_class.new(
-        template: "This is a json object: {\"phone\":{\"number\":100}}",
-        input_variables: []
+        template: "This is a json object: {format_instructions}",
+        input_variables: ["format_instructions"]
       )
-      expect(prompt.format).to eq("This is a json object: {\"phone\":{\"number\":100}}")
+      expect(prompt.format(format_instructions: "{\"phone\":{\"number\":100}}")).to eq("This is a json object: {\"phone\":{\"number\":100}}")
     end
   end
 


### PR DESCRIPTION
When a json structure is passed to Langchain::Prompt::PromptTemplate#format as format_instructions, some of the json structure in the output is missing.

Specifically, if the input json structure is nested, it ends with `...}} `, and if you input such a json, the output result will be `...} `, and the brace is missing. This is not the intended result.

In this Pull Request, this has been changed so that the output result of nested JSON structures will not be broken.