### PR TITLE
Add Support for Ollama WebUI Security

### DIFF
--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -33,6 +33,7 @@ module Langchain::LLM
 
     # Initialize the Ollama client
     # @param url [String] The URL of the Ollama instance
+    # @param api_key [String] The API key to use. This is optional and used when you expose Ollama API using Open WebUI
     # @param default_options [Hash] The default options to use
     #
     def initialize(url: "http://localhost:11434", api_key: nil, default_options: {})

--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -270,14 +270,14 @@ module Langchain::LLM
         conn.request :json
         conn.response :json
         conn.response :raise_error
-        conn.response :logger, nil, { headers: true, bodies: true, errors: true }
+        conn.response :logger, nil, {headers: true, bodies: true, errors: true}
       end
     end
 
     def auth_headers
       return unless @api_key
 
-      { 'Authorization' => "Bearer #{@api_key}" }
+      {"Authorization" => "Bearer #{@api_key}"}
     end
 
     def json_responses_chunk_handler(&block)

--- a/spec/langchain/llm/ollama_spec.rb
+++ b/spec/langchain/llm/ollama_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Langchain::LLM::Ollama do
     end
 
     it "sets auth headers if api_key is passed" do
-      subject = described_class.new(url: "http://localhost)", api_key: 'abc123')
+      subject = described_class.new(url: "http://localhost)", api_key: "abc123")
 
-      expect(subject.send(:client).headers).to include('Authorization' => 'Bearer abc123')
+      expect(subject.send(:client).headers).to include("Authorization" => "Bearer abc123")
     end
   end
 

--- a/spec/langchain/llm/ollama_spec.rb
+++ b/spec/langchain/llm/ollama_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Langchain::LLM::Ollama do
       expect { described_class.new }.not_to raise_error
       expect(described_class.new.url).to eq("http://localhost:11434")
     end
+
+    it "sets auth headers if api_key is passed" do
+      subject = described_class.new(url: "http://localhost)", api_key: 'abc123')
+
+      expect(subject.send(:client).headers).to include('Authorization' => 'Bearer abc123')
+    end
   end
 
   describe "#embed" do


### PR DESCRIPTION
We're using Ollama through Open WebUI interface that provides security through API keys, generated for individual users. This PR adds support for passing api key to `Langchain::LLM::Ollama` constructor - if set, it'll add "Authorization" header.