### PR TITLE
Fix Langchain::Assistant when llm is Anthropic

### DIFF
--- a/lib/langchain/tool_definition.rb
+++ b/lib/langchain/tool_definition.rb
@@ -105,7 +105,7 @@ module Langchain::ToolDefinition
     # @return [String] JSON string of schemas in Anthropic format
     def to_anthropic_format
       @schemas.values.map do |schema|
-        schema[:function].transform_keys("parameters" => "input_schema")
+        schema[:function].transform_keys(parameters: :input_schema)
       end
     end
 


### PR DESCRIPTION
After `Langchain::ToolDefinition` module was introduced and we got rid of static JSON files in this [PR](https://github.com/patterns-ai-core/langchainrb/pull/708), the tools schema is using symbol hash keys and not string keys hence this change was needed to fix the Langchain::Assistant that become broken unnoticed.