### PR TITLE
remove to_bool gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Drop `to_bool` gem in favour of custom util class
 - Drop `colorize` which is GPL-licensed in favour of `rainbow`
 - Improve Langchain::Tool::Weather tool
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       matrix
       pragmatic_segmenter (~> 0.3.0)
       rainbow (~> 3.1.0)
-      to_bool (~> 2.0.0)
       zeitwerk (~> 2.5)
 
 GEM
@@ -406,7 +405,6 @@ GEM
     strscan (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
-    to_bool (2.0.0)
     treetop (1.6.12)
       polyglot (~> 0.3)
     ttfunk (1.8.0)

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json-schema", "~> 4"
   spec.add_dependency "zeitwerk", "~> 2.5"
   spec.add_dependency "pragmatic_segmenter", "~> 0.3.0"
-  spec.add_dependency "to_bool", "~> 2.0.0"
   spec.add_dependency "matrix"
 
   # development dependencies

--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -3,7 +3,6 @@
 require "logger"
 require "pathname"
 require "rainbow"
-require "to_bool"
 require "zeitwerk"
 loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/langchainrb.rb")

--- a/lib/langchain/evals/ragas/faithfulness.rb
+++ b/lib/langchain/evals/ragas/faithfulness.rb
@@ -47,7 +47,7 @@ module Langchain
           verdicts = match.captures.first
           verdicts
             .split(".")
-            .count { |value| value.strip.to_boolean }
+            .count { |value| to_boolean(value.strip) }
         end
 
         def statements_verification(statements:, context:)
@@ -78,6 +78,10 @@ module Langchain
           @template_one ||= Langchain::Prompt.load_from_path(
             file_path: Langchain.root.join("langchain/evals/ragas/prompts/faithfulness_statements_extraction.yml")
           )
+        end
+
+        def to_boolean(value)
+          Langchain::Utils::ToBoolean.new.to_bool(value)
         end
       end
     end

--- a/lib/langchain/utils/to_boolean.rb
+++ b/lib/langchain/utils/to_boolean.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Langchain
+  module Utils
+    class ToBoolean
+      TRUTHABLE_STRINGS = %w[1 true t yes y]
+      private_constant :TRUTHABLE_STRINGS
+
+      def to_bool(value)
+        case value
+        when String
+          TRUTHABLE_STRINGS.include?(value.downcase)
+        when Integer
+          value == 1
+        when TrueClass
+          true
+        when FalseClass
+          false
+        when Symbol
+          to_bool(value.to_s)
+        else
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/langchain/utils/to_boolean_spec.rb
+++ b/spec/langchain/utils/to_boolean_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Langchain::Utils::ToBoolean do
+  describe "#to_bool" do
+    subject(:to_bool) { described_class.new.to_bool(value) }
+
+    context "when Integer" do
+      context "when 1" do
+        let(:value) { 1 }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when 2" do
+        let(:value) { 2 }
+
+        it { is_expected.to eq false }
+      end
+    end
+
+    context "when String" do
+      context "when '1'" do
+        let(:value) { "1" }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when 'true'" do
+        let(:value) { "true" }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when 't'" do
+        let(:value) { "t" }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when 'yes'" do
+        let(:value) { "yes" }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when 'y'" do
+        let(:value) { "y" }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when 'f'" do
+        let(:value) { "f" }
+
+        it { is_expected.to eq false }
+      end
+
+      context "when 'false'" do
+        let(:value) { "false" }
+
+        it { is_expected.to eq false }
+      end
+    end
+
+    context "when Symbol" do
+      context "when :1" do
+        let(:value) { :"1" }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when :true" do
+        let(:value) { :true }  # standard:disable Lint/BooleanSymbol
+
+        it { is_expected.to eq true }
+      end
+
+      context "when :t" do
+        let(:value) { :t }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when :yes" do
+        let(:value) { :yes }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when :y" do
+        let(:value) { :y }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when :f" do
+        let(:value) { :f }
+
+        it { is_expected.to eq false }
+      end
+
+      context "when :false" do
+        let(:value) { :false } # standard:disable Lint/BooleanSymbol
+
+        it { is_expected.to eq false }
+      end
+    end
+
+    context "when TrueClass" do
+      let(:value) { true }
+
+      it { is_expected.to eq true }
+    end
+
+    context "when FalseClass" do
+      let(:value) { false }
+
+      it { is_expected.to eq false }
+    end
+
+    context "when nil" do
+      let(:value) { nil }
+
+      it { is_expected.to eq false }
+    end
+
+    context "when Float" do
+      context "when 1.0" do
+        let(:value) { 1.0 }
+
+        it { is_expected.to eq false }
+      end
+    end
+
+    context "when some other object" do
+      let(:value) { described_class.new }
+
+      it { is_expected.to eq false }
+    end
+  end
+end


### PR DESCRIPTION
License finder reported one more issue besides `colorize` - that `to_bool` has _undefined_ license (which is odd as it clearly has MIT license, but apparently something is off with the gem's metadata). Seems like the best solution was to drop the gem and just implement a simple utility function:

- it's inline with the direction mentioned here about reducing number of dependencies: https://github.com/patterns-ai-core/langchainrb/issues/588
- solves license issues
- removes monkeypatch that _to_bool_ introduces for all objects 