### PR TITLE
Add support for bulk embedding in Ollama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ## [0.15.2] - 2024-08-23
 - Add Assistant#add_messages() method and fix Assistant#messages= method
 
+- Add support for bulk embedding in Ollama
+
 ## [0.15.1] - 2024-08-19
 - Drop `to_bool` gem in favour of custom util class
 - Drop `colorize` which is GPL-licensed in favour of `rainbow`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 ## [Unreleased]
 - Improve the Langchain::Tool::Database tool
 - Allow explictly setting tool_choice on the Assistant instance
+- Add support for bulk embedding in Ollama
 
 ## [0.15.3] - 2024-08-27
 - Fix OpenAI#embed when text-embedding-ada-002 is used
 
 ## [0.15.2] - 2024-08-23
 - Add Assistant#add_messages() method and fix Assistant#messages= method
-
-- Add support for bulk embedding in Ollama
 
 ## [0.15.1] - 2024-08-19
 - Drop `to_bool` gem in favour of custom util class

--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -200,6 +200,7 @@ module Langchain::LLM
     def embed(
       text:,
       model: defaults[:embeddings_model_name],
+      input: [],
       mirostat: nil,
       mirostat_eta: nil,
       mirostat_tau: nil,
@@ -219,7 +220,8 @@ module Langchain::LLM
     )
       parameters = {
         prompt: text,
-        model: model
+        model: model,
+        input: input
       }.compact
 
       llm_parameters = {

--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -198,9 +198,8 @@ module Langchain::LLM
     # @return [Langchain::LLM::OllamaResponse] Response object
     #
     def embed(
-      text: nil,
+      text:,
       model: defaults[:embeddings_model_name],
-      input: [],
       mirostat: nil,
       mirostat_eta: nil,
       mirostat_tau: nil,
@@ -221,7 +220,7 @@ module Langchain::LLM
       parameters = {
         prompt: text,
         model: model,
-        input: input
+        input: Array(text)
       }.compact
 
       llm_parameters = {

--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -218,7 +218,6 @@ module Langchain::LLM
       top_p: nil
     )
       parameters = {
-        prompt: text,
         model: model,
         input: Array(text)
       }.compact

--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -245,7 +245,7 @@ module Langchain::LLM
 
       parameters[:options] = llm_parameters.compact
 
-      response = client.post("api/embeddings") do |req|
+      response = client.post("api/embed") do |req|
         req.body = parameters
       end
 

--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -198,7 +198,7 @@ module Langchain::LLM
     # @return [Langchain::LLM::OllamaResponse] Response object
     #
     def embed(
-      text:,
+      text: nil,
       model: defaults[:embeddings_model_name],
       input: [],
       mirostat: nil,

--- a/lib/langchain/llm/response/ollama_response.rb
+++ b/lib/langchain/llm/response/ollama_response.rb
@@ -28,7 +28,7 @@ module Langchain::LLM
     end
 
     def embeddings
-      [raw_response&.dig("embedding")]
+      raw_response&.dig("embeddings") || []
     end
 
     def role

--- a/spec/langchain/llm/ollama_spec.rb
+++ b/spec/langchain/llm/ollama_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Langchain::LLM::Ollama do
 
   describe "#embed" do
     let(:response_body) {
-      {"embedding" => [0.1, 0.2, 0.3]}
+      {"embeddings" => [[0.1, 0.2, 0.3]]}
     }
 
     before do
@@ -35,6 +35,16 @@ RSpec.describe Langchain::LLM::Ollama do
     it "returns an embedding" do
       expect(subject.embed(text: "Hello, world!")).to be_a(Langchain::LLM::OllamaResponse)
       expect(subject.embed(text: "Hello, world!").embedding.count).to eq(3)
+    end
+
+    context "when the JSON response contains no embeddings" do
+      let(:response_body) {
+        {"embeddings" => []}
+      }
+
+      it "#embedding returns nil" do
+        expect(subject.embed(text: "Hello, world!").embedding).to be nil
+      end
     end
   end
 

--- a/spec/langchain/llm/ollama_spec.rb
+++ b/spec/langchain/llm/ollama_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe Langchain::LLM::Ollama do
       expect(subject.embed(text: "Hello, world!").embedding.count).to eq(3)
     end
 
+    it "sends an input array to the client" do
+      subject.embed(text: "Hello, world!")
+
+      expect(client).to have_received(:post) do |path, &block|
+        req = double("request").as_null_object
+        block.call(req)
+        expect(req).to have_received(:body=).with(hash_including(input: ["Hello, world!"]))
+      end
+    end
+
     context "when the JSON response contains no embeddings" do
       let(:response_body) {
         {"embeddings" => []}


### PR DESCRIPTION
# Description

As of [v0.3.4](https://github.com/ollama/ollama/releases/tag/v0.3.4) Ollama supports bulk embedding. This PR adds support for bulk embeddings via a new `input:` keyword param

# Changes made

- Added the `input:` keyword param to the `#embed` method
- Made the `text:` keyword param optional (*caveat:* this will no longer throw an error if you omit it)
- Updated related method `#embeddings`
- Updated Ollama API endpoint for embeddings
- Updated specs

# Why this change is needed

- The API for bulk embedding requires the `input:` keyword param with an array of strings
- `#embed` currently requires the `text:` keyword param, which is unused when doing bulk embedding

# Open topics

- You can now call `#embed` but pass neither `text:` nor `input:` and it won't throw an error. Is there a preferred way to validate inputs when not relying on keyword argument defaults?