### PR TITLE
Fix OpenAI#embed when text-embedding-ada-002 is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Fix OpenAI#embed when text-embedding-ada-002 is used
 
 ## [0.15.2] - 2024-08-23
 - Add Assistant#add_messages() method and fix Assistant#messages= method

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -80,6 +80,9 @@ module Langchain::LLM
         parameters[:dimensions] = EMBEDDING_SIZES[model]
       end
 
+      # dimensions parameter not supported by text-embedding-ada-002 model
+      parameters.delete(:dimensions) if model == "text-embedding-ada-002"
+
       response = with_api_error_handling do
         client.embeddings(parameters: parameters)
       end

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -142,7 +142,8 @@ RSpec.describe Langchain::LLM::OpenAI do
         end
 
         let(:expected_parameters) do
-          base_parameters.merge!({dimensions: dimensions}) unless model == "text-embedding-ada-002"
+          base_parameters[:dimensions] = dimensions unless model == "text-embedding-ada-002"
+          base_parameters
         end
 
         let(:response) do

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with text and parameters" do
       let(:parameters) do
-        {parameters: {input: "Hello World", model: "text-embedding-ada-002", user: "id", dimensions: Langchain::LLM::OpenAI::EMBEDDING_SIZES["text-embedding-ada-002"]}}
+        {parameters: {input: "Hello World", model: "text-embedding-ada-002", user: "id"}}
       end
 
       it "returns an embedding" do
@@ -142,7 +142,7 @@ RSpec.describe Langchain::LLM::OpenAI do
         end
 
         let(:expected_parameters) do
-          base_parameters.merge({dimensions: dimensions})
+          base_parameters.merge!({dimensions: dimensions}) unless model == "text-embedding-ada-002"
         end
 
         let(:response) do


### PR DESCRIPTION
Before:
```
irb(main):001> llm = Langchain::LLM::OpenAI.new(api_key: ENV['OPENAI_API_KEY'])
=>
#<Langchain::LLM::OpenAI:0x00000001288f9d68
...
irb(main):002> llm.embed(text:"hello", model:"text-embedding-ada-002")
/Users/andrei/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/faraday-2.9.0/lib/faraday/response/raise_error.rb:16:in `on_complete': the server responded with status 400 (Faraday::BadRequestError)
```

After:
```
irb(main):001> llm = Langchain::LLM::OpenAI.new(api_key: ENV['OPENAI_API_KEY'])
=>
#<Langchain::LLM::OpenAI:0x0000000107ae1e08
...
irb(main):002> llm.embed(text:"hello", model:"text-embedding-ada-002")
=>
#<Langchain::LLM::OpenAIResponse:0x000000010b95ac98
```

Explanation:
`text-embedding-ada-002` does not support the `dimensions` parameter by the OpenAI API.