### PR TITLE
Fix annonymous block issue

### DIFF
--- a/lib/langchain/tool_definition.rb
+++ b/lib/langchain/tool_definition.rb
@@ -40,8 +40,8 @@ module Langchain::ToolDefinition
   # @param method_name [Symbol] Name of the method to define
   # @param description [String] Description of the function
   # @yield Block that defines the parameters for the function
-  def define_function(method_name, description:, &)
-    function_schemas.add_function(method_name:, description:, &)
+  def define_function(method_name, description:, &block)
+    function_schemas.add_function(method_name:, description:, &block)
   end
 
   # Returns the FunctionSchemas instance for this tool


### PR DESCRIPTION
Reported in Discord:
```
Hello i built my portfolio with a chatbot using the Langchain gem and i have a problem trying to deploy de app to heroku.
Y tried to emulate the enviroment (production) in my local the issue is the same.
 Booting Puma
=> Rails 7.1.3.4 application starting in production
=> Run bin/rails server --help for more startup options
Exiting
/home/puzzle404/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require': /home/puzzle404/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/langchainrb-0.15.4/lib/langchain/tool_definition.rb:46: no anonymous block parameter (SyntaxError) 

Seems like the problem could be in tool_definition.rb:46 file but i'm blocked with this. Any help is welcome! Thanks! 👍
I'm using ruby 3.1.2
```

