### PR TITLE
Fix syntax errors for compatibility with Ruby 3.1.x

### DIFF
--- a/lib/langchain/tool_definition.rb
+++ b/lib/langchain/tool_definition.rb
@@ -77,7 +77,7 @@ module Langchain::ToolDefinition
     def add_function(method_name:, description:, &block)
       name = "#{@tool_name}__#{method_name}"
 
-      if block_given?
+      if block
         parameters = ParameterBuilder.new(parent_type: "object").build(&block)
 
         if parameters[:properties].empty?
@@ -147,7 +147,7 @@ module Langchain::ToolDefinition
 
       prop = {type:, description:, enum:}.compact
 
-      if block_given?
+      if block
         nested_schema = ParameterBuilder.new(parent_type: type).build(&block)
 
         case type

--- a/lib/langchain/tool_definition.rb
+++ b/lib/langchain/tool_definition.rb
@@ -40,8 +40,8 @@ module Langchain::ToolDefinition
   # @param method_name [Symbol] Name of the method to define
   # @param description [String] Description of the function
   # @yield Block that defines the parameters for the function
-  def define_function(method_name, description:, &)
-    function_schemas.add_function(method_name:, description:, &)
+  def define_function(method_name, description:, &block)
+    function_schemas.add_function(method_name:, description:, &block)
   end
 
   # Returns the FunctionSchemas instance for this tool
@@ -74,11 +74,11 @@ module Langchain::ToolDefinition
     # @param description [String] Description of the function
     # @yield Block that defines the parameters for the function
     # @raise [ArgumentError] If a block is defined and no parameters are specified for the function
-    def add_function(method_name:, description:, &)
+    def add_function(method_name:, description:, &block)
       name = "#{@tool_name}__#{method_name}"
 
       if block_given?
-        parameters = ParameterBuilder.new(parent_type: "object").build(&)
+        parameters = ParameterBuilder.new(parent_type: "object").build(&block)
 
         if parameters[:properties].empty?
           raise ArgumentError, "Function parameters must have at least one property defined within it, if a block is provided"
@@ -142,13 +142,13 @@ module Langchain::ToolDefinition
     # @param required [Boolean] Whether the property is required
     # @yield [Block] Block for nested properties (only for object and array types)
     # @raise [ArgumentError] If any parameter is invalid
-    def property(name = nil, type:, description: nil, enum: nil, required: false, &)
+    def property(name = nil, type:, description: nil, enum: nil, required: false, &block)
       validate_parameters(name:, type:, enum:, required:)
 
       prop = {type:, description:, enum:}.compact
 
       if block_given?
-        nested_schema = ParameterBuilder.new(parent_type: type).build(&)
+        nested_schema = ParameterBuilder.new(parent_type: type).build(&block)
 
         case type
         when "object"


### PR DESCRIPTION
FIX on using block (&) as an argument of a method, changed from '&' to '&block' in tool_definition file. Rspec tested OK