### PR TITLE
Prepend system message

### DIFF
--- a/lib/langchain/assistants/assistant.rb
+++ b/lib/langchain/assistants/assistant.rb
@@ -51,9 +51,8 @@ module Langchain
       raise ArgumentError, "Thread must be an instance of Langchain::Thread" unless @thread.is_a?(Langchain::Thread)
 
       # The first message in the thread should be the system instructions
-      # TODO: What if the user added old messages and the system instructions are already in there? Should this overwrite the existing instructions?
-      initialize_instructions
       # For Google Gemini, and Anthropic system instructions are added to the `system:` param in the `chat` method
+      initialize_instructions
     end
 
     # Add a user message to the thread
@@ -287,7 +286,7 @@ module Langchain
 
     def initialize_instructions
       if llm.is_a?(Langchain::LLM::OpenAI) || llm.is_a?(Langchain::LLM::MistralAI)
-        add_message(role: "system", content: instructions) if instructions
+        self.instructions = @instructions if @instructions
       end
     end
 

--- a/spec/langchain/assistants/assistant_spec.rb
+++ b/spec/langchain/assistants/assistant_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe Langchain::Assistant do
         subject = described_class.new(llm: llm, instructions: instructions)
         expect(subject.thread).to be_a(Langchain::Thread)
       end
+
+      it "the system message always comes first" do
+        thread = Langchain::Thread.new
+        system_message = Langchain::Messages::OpenAIMessage.new(role: "system", content: "System message")
+        user_message = Langchain::Messages::OpenAIMessage.new(role: "user", content: "foo")
+        thread.add_message(system_message)
+        thread.add_message(user_message)
+        assistant = described_class.new(llm: llm, thread: thread, instructions: instructions)
+        expect(assistant.messages.first.role).to eq("system")
+        # Replaces the previous system message
+        expect(assistant.messages.first.content).to eq("You are an expert assistant")
+      end
     end
 
     describe "#add_message" do
@@ -377,6 +389,18 @@ RSpec.describe Langchain::Assistant do
       it "sets new thread if thread is not provided" do
         subject = described_class.new(llm: llm, instructions: instructions)
         expect(subject.thread).to be_a(Langchain::Thread)
+      end
+
+      it "the system message always comes first" do
+        thread = Langchain::Thread.new
+        system_message = Langchain::Messages::OpenAIMessage.new(role: "system", content: "System message")
+        user_message = Langchain::Messages::OpenAIMessage.new(role: "user", content: "foo")
+        thread.add_message(system_message)
+        thread.add_message(user_message)
+        assistant = described_class.new(llm: llm, thread: thread, instructions: instructions)
+        expect(assistant.messages.first.role).to eq("system")
+        # Replaces the previous system message
+        expect(assistant.messages.first.content).to eq("You are an expert assistant")
       end
     end
 


### PR DESCRIPTION
When a thread is provided, instructions should replace the initial system message.