### PR TITLE
Bump unicode gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,7 +413,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode (0.4.4.4)
+    unicode (0.4.4.5)
     unicode-display_width (2.5.0)
     unparser (0.6.13)
       diff-lcs (~> 1.3)


### PR DESCRIPTION
This error should no longer be happening: https://github.com/patterns-ai-core/langchainrb?tab=readme-ov-file#problems in the new `unicode` version.