### PR TITLE
Patch up ContextualLogger

### DIFF
--- a/lib/langchain/contextual_logger.rb
+++ b/lib/langchain/contextual_logger.rb
@@ -49,6 +49,8 @@ module Langchain
         "[#{for_class_name}]:"
       end
       log_line_parts << colorize(args.first, MESSAGE_COLOR_OPTIONS[method])
+      log_line_parts << kwargs if !!kwargs && kwargs.any?
+      log_line_parts << block.call if block
       log_line = log_line_parts.compact.join(" ")
 
       @logger.send(

--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -270,7 +270,7 @@ module Langchain::LLM
         conn.request :json
         conn.response :json
         conn.response :raise_error
-        conn.response :logger, nil, {headers: true, bodies: true, errors: true}
+        conn.response :logger, Langchain.logger, {headers: true, bodies: true, errors: true}
       end
     end
 


### PR DESCRIPTION
* Ollama logging uses the current Langchain.logger.level
* ContextualLogger outputs everything passed in