### PR TITLE
Allow explicitly setting client object on any instance of Langchain::LLM::Base subclass

### DIFF
--- a/lib/langchain/llm/base.rb
+++ b/lib/langchain/llm/base.rb
@@ -24,7 +24,7 @@ module Langchain::LLM
     include Langchain::DependencyHelper
 
     # A client for communicating with the LLM
-    attr_reader :client
+    attr_accessor :client
 
     # Ensuring backward compatibility after https://github.com/patterns-ai-core/langchainrb/pull/586
     # TODO: Delete this method later

--- a/spec/langchain/llm/base_spec.rb
+++ b/spec/langchain/llm/base_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe Langchain::LLM::Base do
     end
   end
 
+  describe "client object" do
+    let(:llm) { TestLLM.new }
+
+    it "can be accessed" do
+      expect(llm).to respond_to(:client)
+    end
+
+    it "can be set" do
+      expect(llm).to respond_to(:client=)
+    end
+  end
+
   describe "#complete" do
     it "raises an error" do
       expect { subject.complete }.to raise_error(NotImplementedError)


### PR DESCRIPTION
You can now set a custom `@client` object on `Langchain::LLM::Base` subclasses. Example:
```ruby
llm = Langchain::LLM::OpenAI.new(...)
llm.client = OpenAI::Client.new(...)
```
