### PR TITLE
Opening the Assistant to accept custom LLM

### DIFF
--- a/lib/langchain/assistant.rb
+++ b/lib/langchain/assistant.rb
@@ -227,7 +227,7 @@ module Langchain
 
     # TODO: If tool_choice = "tool_function_name" and then tool is removed from the assistant, should we set tool_choice back to "auto"?
     def validate_tool_choice!(tool_choice)
-      allowed_tool_choices = llm_adapter.allowed_tool_choices.concat(available_tool_names)
+      allowed_tool_choices = @llm_adapter.allowed_tool_choices.concat(available_tool_names)
       unless allowed_tool_choices.include?(tool_choice)
         raise ArgumentError, "Tool choice must be one of: #{allowed_tool_choices.join(", ")}"
       end
@@ -346,7 +346,7 @@ module Langchain
         tool_choice: tool_choice,
         parallel_tool_calls: parallel_tool_calls
       )
-      @llm.chat(**params, &@block)
+      @llm_adapter.chat(**params, &@block)
     end
 
     # Run the tools automatically
@@ -402,7 +402,7 @@ module Langchain
     end
 
     def available_tool_names
-      llm_adapter.available_tool_names(tools)
+      @llm_adapter.available_tool_names(tools)
     end
 
     def validate_callback!(attr_name, callback)

--- a/lib/langchain/assistant.rb
+++ b/lib/langchain/assistant.rb
@@ -39,6 +39,7 @@ module Langchain
     # @param tool_execution_callback [Proc] A callback function (Proc or lambda) that is called right before a tool function is executed
     def initialize(
       llm:,
+      llm_adapter: LLM::Adapter.build(llm),
       tools: [],
       instructions: nil,
       tool_choice: "auto",
@@ -54,7 +55,7 @@ module Langchain
       end
 
       @llm = llm
-      @llm_adapter = LLM::Adapter.build(llm)
+      @llm_adapter = llm_adapter
 
       @add_message_callback = add_message_callback if validate_callback!("add_message_callback", add_message_callback)
       @tool_execution_callback = tool_execution_callback if validate_callback!("tool_execution_callback", tool_execution_callback)

--- a/lib/langchain/assistant.rb
+++ b/lib/langchain/assistant.rb
@@ -29,7 +29,7 @@ module Langchain
 
     # Create a new assistant
     #
-    # @param llm [Langchain::LLM::Base] LLM instance that the assistant will use
+    # @param llm [Langchain::LLM::Base, Langchain::Assistant::LLM::Adapters::Base] LLM instance that the assistant will use
     # @param tools [Array<Langchain::Tool::Base>] Tools that the assistant has access to
     # @param instructions [String] The system instructions
     # @param tool_choice [String] Specify how tools should be selected. Options: "auto", "any", "none", or <specific function name>
@@ -39,7 +39,6 @@ module Langchain
     # @param tool_execution_callback [Proc] A callback function (Proc or lambda) that is called right before a tool function is executed
     def initialize(
       llm:,
-      llm_adapter: LLM::Adapter.build(llm),
       tools: [],
       instructions: nil,
       tool_choice: "auto",
@@ -55,7 +54,14 @@ module Langchain
       end
 
       @llm = llm
-      @llm_adapter = llm_adapter
+      case llm
+      when Langchain::LLM::Base
+        @llm_adapter = LLM::Adapter.build(llm)
+      when Langchain::Assistant::LLM::Adapters::Base
+        @llm_adapter = llm
+      else
+        raise ArgumentError, "LLM has to be object extending Langchain::LLM::Base or Langchain::Assistant::LLM::Adapters::Base"
+      end
 
       @add_message_callback = add_message_callback if validate_callback!("add_message_callback", add_message_callback)
       @tool_execution_callback = tool_execution_callback if validate_callback!("tool_execution_callback", tool_execution_callback)

--- a/lib/langchain/assistant/llm/adapter.rb
+++ b/lib/langchain/assistant/llm/adapter.rb
@@ -7,17 +7,17 @@ module Langchain
       class Adapter
         def self.build(llm)
           if llm.is_a?(Langchain::LLM::Anthropic)
-            LLM::Adapters::Anthropic.new
+            LLM::Adapters::Anthropic.new(llm: llm)
           elsif llm.is_a?(Langchain::LLM::AwsBedrock) && llm.defaults[:chat_model].include?("anthropic")
-            LLM::Adapters::AwsBedrockAnthropic.new
+            LLM::Adapters::AwsBedrockAnthropic.new(llm: llm)
           elsif llm.is_a?(Langchain::LLM::GoogleGemini) || llm.is_a?(Langchain::LLM::GoogleVertexAI)
-            LLM::Adapters::GoogleGemini.new
+            LLM::Adapters::GoogleGemini.new(llm: llm)
           elsif llm.is_a?(Langchain::LLM::MistralAI)
-            LLM::Adapters::MistralAI.new
+            LLM::Adapters::MistralAI.new(llm: llm)
           elsif llm.is_a?(Langchain::LLM::Ollama)
-            LLM::Adapters::Ollama.new
+            LLM::Adapters::Ollama.new(llm: llm)
           elsif llm.is_a?(Langchain::LLM::OpenAI)
-            LLM::Adapters::OpenAI.new
+            LLM::Adapters::OpenAI.new(llm: llm)
           else
             raise ArgumentError, "Unsupported LLM type: #{llm.class}"
           end

--- a/lib/langchain/assistant/llm/adapters/anthropic.rb
+++ b/lib/langchain/assistant/llm/adapters/anthropic.rb
@@ -55,7 +55,18 @@ module Langchain
 
           # Build the tools for the Anthropic API
           def build_tools(tools)
-            tools.map { |tool| tool.class.function_schemas.to_anthropic_format }.flatten
+            tools.map { |tool|
+              tool.class.function_schemas.functions.map { |schema|
+                # Adds a default input_schema if no parameters are present
+                schema[:function][:parameters] ||= {
+                  type: "object",
+                  properties: {},
+                  required: []
+                }
+
+                schema[:function].transform_keys(parameters: :input_schema)
+              }
+            }.flatten
           end
 
           # Get the allowed assistant.tool_choice values for Anthropic

--- a/lib/langchain/assistant/llm/adapters/base.rb
+++ b/lib/langchain/assistant/llm/adapters/base.rb
@@ -5,6 +5,14 @@ module Langchain
     module LLM
       module Adapters
         class Base
+          def initialize(llm:)
+            @llm = llm
+          end
+
+          def chat(...)
+            @llm.chat(...)
+          end
+
           # Build the chat parameters for the LLM
           #
           # @param messages [Array] The messages

--- a/lib/langchain/assistant/llm/adapters/google_gemini.rb
+++ b/lib/langchain/assistant/llm/adapters/google_gemini.rb
@@ -62,7 +62,11 @@ module Langchain
           # @param tools [Array<Langchain::Tool::Base>] The tools
           # @return [Array] The tools in Google Gemini format
           def build_tools(tools)
-            tools.map { |tool| tool.class.function_schemas.to_google_gemini_format }.flatten
+            tools.map { |tool|
+              tool.class.function_schemas.functions.map { |function|
+                function[:function]
+              }
+            }.flatten
           end
 
           # Get the allowed assistant.tool_choice values for Google Gemini

--- a/lib/langchain/assistant/llm/adapters/mistral_ai.rb
+++ b/lib/langchain/assistant/llm/adapters/mistral_ai.rb
@@ -64,7 +64,7 @@ module Langchain
 
           # Build the tools for the Mistral AI LLM
           def build_tools(tools)
-            tools.map { |tool| tool.class.function_schemas.to_openai_format }.flatten
+            tools.map { |tool| tool.class.function_schemas.functions }.flatten
           end
 
           # Get the allowed assistant.tool_choice values for Mistral AI

--- a/lib/langchain/assistant/llm/adapters/ollama.rb
+++ b/lib/langchain/assistant/llm/adapters/ollama.rb
@@ -83,7 +83,7 @@ module Langchain
           private
 
           def build_tools(tools)
-            tools.map { |tool| tool.class.function_schemas.to_openai_format }.flatten
+            tools.map { |tool| tool.class.function_schemas.functions }.flatten
           end
         end
       end

--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -63,7 +63,7 @@ module Langchain
 
           # Build the tools for the OpenAI LLM
           def build_tools(tools)
-            tools.map { |tool| tool.class.function_schemas.to_openai_format }.flatten
+            tools.map { |tool| tool.class.function_schemas.functions }.flatten
           end
 
           # Get the allowed assistant.tool_choice values for OpenAI

--- a/lib/langchain/tool_definition.rb
+++ b/lib/langchain/tool_definition.rb
@@ -98,22 +98,6 @@ module Langchain::ToolDefinition
       @schemas.values
     end
 
-    # Converts schemas to Anthropic-compatible format
-    #
-    # @return [String] JSON string of schemas in Anthropic format
-    def to_anthropic_format
-      @schemas.values.map do |schema|
-        # Adds a default input_schema if no parameters are present
-        schema[:function][:parameters] ||= {
-          type: "object",
-          properties: {},
-          required: []
-        }
-
-        schema[:function].transform_keys(parameters: :input_schema)
-      end
-    end
-
     # Converts schemas to Google Gemini-compatible format
     #
     # @return [String] JSON string of schemas in Google Gemini format

--- a/lib/langchain/tool_definition.rb
+++ b/lib/langchain/tool_definition.rb
@@ -91,10 +91,10 @@ module Langchain::ToolDefinition
       }
     end
 
-    # Converts schemas to OpenAI-compatible format
+    # Returns list of schemas
     #
     # @return [String] JSON string of schemas in OpenAI format
-    def to_openai_format
+    def functions
       @schemas.values
     end
 

--- a/lib/langchain/tool_definition.rb
+++ b/lib/langchain/tool_definition.rb
@@ -97,13 +97,6 @@ module Langchain::ToolDefinition
     def functions
       @schemas.values
     end
-
-    # Converts schemas to Google Gemini-compatible format
-    #
-    # @return [String] JSON string of schemas in Google Gemini format
-    def to_google_gemini_format
-      @schemas.values.map { |schema| schema[:function] }
-    end
   end
 
   # Builds parameter schemas for functions

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -1571,22 +1571,43 @@ RSpec.describe Langchain::Assistant do
 
     subject {
       described_class.new(
-        llm: llm,
-        llm_adapter: llm_adapter,
+        llm: llm_adapter,
         tools: [calculator],
         instructions: instructions
       )
     }
 
     describe ".new" do
-      it "initiates an assistant without error" do
-        expect { subject }.not_to raise_error
+      it "initiates an assistant without error using adapter as LLM" do
+        expect {
+          described_class.new(
+            llm: llm_adapter,
+            tools: [calculator],
+            instructions: instructions
+          )
+        }.not_to raise_error
+      end
+
+      it "raises an error when using unknown LLM" do
+        expect {
+          described_class.new(
+            llm: llm,
+            tools: [calculator],
+            instructions: instructions
+          )
+        }.to raise_error
       end
     end
 
     describe "#messages" do
       it "returns list of messages" do
-        expect(subject.messages).to contain_exactly(
+        expect(
+          described_class.new(
+            llm: llm_adapter,
+            tools: [calculator],
+            instructions: instructions
+          ).messages
+        ).to contain_exactly(
           an_object_having_attributes(
             role: "system",
             content: "You are an expert assistant"

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -1565,7 +1565,7 @@ RSpec.describe Langchain::Assistant do
         end
       end
     end
-    let(:llm_adapter) { llm_adapter_class.new }
+    let(:llm_adapter) { llm_adapter_class.new(llm: llm) }
     let(:calculator) { Langchain::Tool::Calculator.new }
     let(:instructions) { "You are an expert assistant" }
 

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -136,6 +136,11 @@ RSpec.describe Langchain::Assistant do
         expect(assistant.messages.first.content).to eq("You are an expert assistant")
       end
 
+      it "skips a system message creation for empty instructions" do
+        assistant = described_class.new(llm: llm, instructions: nil)
+        expect(assistant.messages).to be_empty
+      end
+
       it "the system message always comes first" do
         assistant = described_class.new(llm: llm, instructions: instructions)
         assistant.add_message(role: "system", content: "System message")
@@ -512,6 +517,11 @@ RSpec.describe Langchain::Assistant do
         described_class.new(llm: llm, instructions: instructions)
         expect(subject.messages.first.role).to eq("system")
         expect(subject.messages.first.content).to eq("You are an expert assistant")
+      end
+
+      it "skips a system message creation for empty instructions" do
+        assistant = described_class.new(llm: llm, instructions: nil)
+        expect(assistant.messages).to be_empty
       end
 
       it "the system message always comes first" do
@@ -1348,6 +1358,11 @@ RSpec.describe Langchain::Assistant do
         assistant = described_class.new(llm: llm, instructions: instructions)
         expect(assistant.messages.first.role).to eq("system")
         expect(assistant.messages.first.content).to eq("You are an expert assistant")
+      end
+
+      it "skips a system message creation for empty instructions" do
+        assistant = described_class.new(llm: llm, instructions: nil)
+        expect(assistant.messages).to be_empty
       end
 
       it "the system message always comes first" do

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -1042,7 +1042,22 @@ RSpec.describe Langchain::Assistant do
           allow(subject.llm).to receive(:chat)
             .with(
               messages: [{role: "user", parts: [{text: "Please calculate 2+2"}]}],
-              tools: calculator.class.function_schemas.to_google_gemini_format,
+              tools: [
+                {
+                  name: "langchain_tool_calculator__execute",
+                  description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+                  parameters: {
+                    properties: {
+                      input: {
+                        description: "Math expression",
+                        type: "string"
+                      }
+                    },
+                    required: ["input"],
+                    type: "object"
+                  }
+                }
+              ],
               tool_choice: {function_calling_config: {mode: "auto"}},
               system: instructions
             )
@@ -1083,7 +1098,22 @@ RSpec.describe Langchain::Assistant do
                 {role: "model", parts: [{"functionCall" => {"name" => "langchain_tool_calculator__execute", "args" => {"input" => "2+2"}}}]},
                 {role: "function", parts: [{functionResponse: {name: "langchain_tool_calculator__execute", response: {name: "langchain_tool_calculator__execute", content: "4.0"}}}]}
               ],
-              tools: calculator.class.function_schemas.to_google_gemini_format,
+              tools: [
+                {
+                  name: "langchain_tool_calculator__execute",
+                  description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+                  parameters: {
+                    properties: {
+                      input: {
+                        description: "Math expression",
+                        type: "string"
+                      }
+                    },
+                    required: ["input"],
+                    type: "object"
+                  }
+                }
+              ],
               tool_choice: {function_calling_config: {mode: "auto"}},
               system: instructions
             )

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -1261,7 +1261,22 @@ RSpec.describe Langchain::Assistant do
           allow(subject.llm).to receive(:chat)
             .with(
               messages: [{role: "user", content: [{text: "Please calculate 2+2", type: "text"}]}],
-              tools: calculator.class.function_schemas.to_anthropic_format,
+              tools: [
+                {
+                  name: "langchain_tool_calculator__execute",
+                  description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+                  input_schema: {
+                    properties: {
+                      input: {
+                        description: "Math expression",
+                        type: "string"
+                      }
+                    },
+                    required: ["input"],
+                    type: "object"
+                  }
+                }
+              ],
               tool_choice: {disable_parallel_tool_use: false, type: "auto"},
               system: instructions
             )
@@ -1320,7 +1335,22 @@ RSpec.describe Langchain::Assistant do
                 ]},
                 {role: "user", content: [{type: "tool_result", tool_use_id: "toolu_014eSx9oBA5DMe8gZqaqcJ3H", content: "4.0"}]}
               ],
-              tools: calculator.class.function_schemas.to_anthropic_format,
+              tools: [
+                {
+                  name: "langchain_tool_calculator__execute",
+                  description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+                  input_schema: {
+                    properties: {
+                      input: {
+                        description: "Math expression",
+                        type: "string"
+                      }
+                    },
+                    required: ["input"],
+                    type: "object"
+                  }
+                }
+              ],
               tool_choice: {disable_parallel_tool_use: false, type: "auto"},
               system: instructions
             )

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -870,6 +870,13 @@ RSpec.describe Langchain::Assistant do
       )
     }
 
+    describe "#initialize" do
+      it "doesn't propagate instructions to messages" do
+        described_class.new(llm: llm, instructions: instructions)
+        expect(subject.messages).to be_empty
+      end
+    end
+
     describe "#instructions=" do
       it "resets instructions" do
         subject.instructions = "New instructions"
@@ -891,6 +898,13 @@ RSpec.describe Langchain::Assistant do
         instructions: instructions
       )
     }
+
+    describe "#initialize" do
+      it "doesn't propagate instructions to messages" do
+        described_class.new(llm: llm, instructions: instructions)
+        expect(subject.messages).to be_empty
+      end
+    end
 
     describe "#add_message" do
       it "adds a message to the thread" do
@@ -1077,6 +1091,13 @@ RSpec.describe Langchain::Assistant do
         instructions: instructions
       )
     }
+
+    describe "#initialize" do
+      it "doesn't propagate instructions to messages" do
+        described_class.new(llm: llm, instructions: instructions)
+        expect(subject.messages).to be_empty
+      end
+    end
 
     describe "#add_message" do
       it "adds a message to the thread" do
@@ -1321,6 +1342,23 @@ RSpec.describe Langchain::Assistant do
         instructions: instructions
       )
     }
+
+    describe "#initialize" do
+      it "adds a system message to the thread" do
+        assistant = described_class.new(llm: llm, instructions: instructions)
+        expect(assistant.messages.first.role).to eq("system")
+        expect(assistant.messages.first.content).to eq("You are an expert assistant")
+      end
+
+      it "the system message always comes first" do
+        assistant = described_class.new(llm: llm, instructions: instructions)
+        assistant.add_message(role: "system", content: "System message")
+        assistant.add_message(role: "user", content: "foo")
+        expect(assistant.messages.first.role).to eq("system")
+        # Replaces the previous system message
+        expect(assistant.messages.first.content).to eq("You are an expert assistant")
+      end
+    end
 
     xdescribe "#set_state_for" do
       xcontext "when response contains completion" do

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -237,7 +237,25 @@ RSpec.describe Langchain::Assistant do
                 {role: "system", content: [{type: "text", text: instructions}]},
                 {role: "user", content: [{type: "text", text: "Please calculate 2+2"}]}
               ],
-              tools: calculator.class.function_schemas.to_openai_format,
+              tools: [
+                {
+                  function: {
+                    description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+                    name: "langchain_tool_calculator__execute",
+                    parameters: {
+                      properties: {
+                        input: {
+                          description: "Math expression",
+                          type: "string"
+                        }
+                      },
+                      required: ["input"],
+                      type: "object"
+                    }
+                  },
+                  type: "function"
+                }
+              ],
               tool_choice: "auto",
               parallel_tool_calls: true
             )
@@ -290,7 +308,25 @@ RSpec.describe Langchain::Assistant do
                 ]},
                 {content: [{type: "text", text: "4.0"}], role: "tool", tool_call_id: "call_9TewGANaaIjzY31UCpAAGLeV"}
               ],
-              tools: calculator.class.function_schemas.to_openai_format,
+              tools: [
+                {
+                  function: {
+                    description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+                    name: "langchain_tool_calculator__execute",
+                    parameters: {
+                      properties: {
+                        input: {
+                          description: "Math expression",
+                          type: "string"
+                        }
+                      },
+                      required: ["input"],
+                      type: "object"
+                    }
+                  },
+                  type: "function"
+                }
+              ],
               tool_choice: "auto",
               parallel_tool_calls: true
             )
@@ -610,7 +646,25 @@ RSpec.describe Langchain::Assistant do
                 {role: "system", content: [{type: "text", text: instructions}]},
                 {role: "user", content: [{type: "text", text: "Please calculate 2+2"}]}
               ],
-              tools: calculator.class.function_schemas.to_openai_format,
+              tools: [
+                {
+                  function: {
+                    description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+                    name: "langchain_tool_calculator__execute",
+                    parameters: {
+                      properties: {
+                        input: {
+                          description: "Math expression",
+                          type: "string"
+                        }
+                      },
+                      required: ["input"],
+                      type: "object"
+                    }
+                  },
+                  type: "function"
+                }
+              ],
               tool_choice: "auto"
             )
             .and_return(Langchain::LLM::MistralAIResponse.new(raw_mistralai_response))
@@ -662,7 +716,25 @@ RSpec.describe Langchain::Assistant do
                 ]},
                 {content: "4.0", role: "tool", tool_call_id: "call_9TewGANaaIjzY31UCpAAGLeV"}
               ],
-              tools: calculator.class.function_schemas.to_openai_format,
+              tools: [
+                {
+                  function: {
+                    description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+                    name: "langchain_tool_calculator__execute",
+                    parameters: {
+                      properties: {
+                        input: {
+                          description: "Math expression",
+                          type: "string"
+                        }
+                      },
+                      required: ["input"],
+                      type: "object"
+                    }
+                  },
+                  type: "function"
+                }
+              ],
               tool_choice: "auto"
             )
             .and_return(Langchain::LLM::MistralAIResponse.new(raw_mistralai_response2))

--- a/spec/langchain/assistant/llm/adapters/anthropic_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/anthropic_spec.rb
@@ -13,7 +13,22 @@ RSpec.describe Langchain::Assistant::LLM::Adapters::Anthropic do
         )
       ).to eq({
         messages: [{role: "user", content: "Hello"}],
-        tools: Langchain::Tool::Calculator.function_schemas.to_anthropic_format,
+        tools: [
+          {
+            name: "langchain_tool_calculator__execute",
+            description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+            input_schema: {
+              properties: {
+                input: {
+                  description: "Math expression",
+                  type: "string"
+                }
+              },
+              required: ["input"],
+              type: "object"
+            }
+          }
+        ],
         tool_choice: {disable_parallel_tool_use: true, name: "langchain_tool_calculator__execute", type: "tool"},
         system: "Instructions"
       })

--- a/spec/langchain/assistant/llm/adapters/anthropic_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/anthropic_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Langchain::Assistant::LLM::Adapters::Anthropic do
+  let(:llm) { Langchain::LLM::Anthropic.new(api_key: "123") }
+  subject { described_class.new(llm: llm) }
+
   describe "#build_chat_params" do
     it "returns the chat parameters" do
       expect(

--- a/spec/langchain/assistant/llm/adapters/aws_bedrock_anthropic_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/aws_bedrock_anthropic_spec.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Langchain::Assistant::LLM::Adapters::AwsBedrockAnthropic do
+  let(:llm) { Langchain::LLM::AwsBedrock.new }
+  subject { described_class.new(llm: llm) }
+
+  before do
+    stub_const("ENV", ENV.to_hash.merge("AWS_REGION" => "us-east-1"))
+  end
+
   describe "#build_tool_choice" do
     it "returns the tool choice object with 'auto'" do
       expect(subject.send(:build_tool_choice, "auto", true)).to eq({type: "auto"})

--- a/spec/langchain/assistant/llm/adapters/base_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/base_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Langchain::Assistant::LLM::Adapters::Base do
+  let(:llm) { Class.new(Langchain::Assistant::LLM::Adapters::Base) }
+  subject { described_class.new(llm: llm) }
+
   describe "#build_chat_params" do
     it "raises NotImplementedError" do
       expect { subject.build_chat_params(tools: [], instructions: "", messages: [], tool_choice: "", parallel_tool_calls: false) }.to raise_error(NotImplementedError)

--- a/spec/langchain/assistant/llm/adapters/google_gemini_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/google_gemini_spec.rb
@@ -13,7 +13,22 @@ RSpec.describe Langchain::Assistant::LLM::Adapters::GoogleGemini do
         )
       ).to eq({
         messages: [{role: "user", content: "Hello"}],
-        tools: Langchain::Tool::Calculator.function_schemas.to_google_gemini_format,
+        tools: [
+          {
+            name: "langchain_tool_calculator__execute",
+            description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+            parameters: {
+              properties: {
+                input: {
+                  description: "Math expression",
+                  type: "string"
+                }
+              },
+              required: ["input"],
+              type: "object"
+            }
+          }
+        ],
         tool_choice: {function_calling_config: {allowed_function_names: ["langchain_tool_calculator__execute"], mode: "any"}},
         system: "Instructions"
       })

--- a/spec/langchain/assistant/llm/adapters/google_gemini_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/google_gemini_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Langchain::Assistant::LLM::Adapters::GoogleGemini do
+  let(:llm) { Langchain::LLM::GoogleGemini.new(api_key: "123") }
+  subject { described_class.new(llm: llm) }
+
   describe "#build_chat_params" do
     it "returns the chat parameters" do
       expect(

--- a/spec/langchain/assistant/llm/adapters/mistral_ai_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/mistral_ai_spec.rb
@@ -13,7 +13,25 @@ RSpec.describe Langchain::Assistant::LLM::Adapters::MistralAI do
         )
       ).to eq({
         messages: [{role: "user", content: "Hello"}],
-        tools: Langchain::Tool::Calculator.function_schemas.to_openai_format,
+        tools: [
+          {
+            function: {
+              description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+              name: "langchain_tool_calculator__execute",
+              parameters: {
+                properties: {
+                  input: {
+                    description: "Math expression",
+                    type: "string"
+                  }
+                },
+                required: ["input"],
+                type: "object"
+              }
+            },
+            type: "function"
+          }
+        ],
         tool_choice: {"function" => {"name" => "langchain_tool_calculator__execute"}, "type" => "function"}
       })
     end

--- a/spec/langchain/assistant/llm/adapters/mistral_ai_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/mistral_ai_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Langchain::Assistant::LLM::Adapters::MistralAI do
+  let(:llm) { Langchain::LLM::MistralAI.new(api_key: "123") }
+  subject { described_class.new(llm: llm) }
+
   describe "#build_chat_params" do
     it "returns the chat parameters" do
       expect(

--- a/spec/langchain/assistant/llm/adapters/ollama_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/ollama_spec.rb
@@ -13,7 +13,25 @@ RSpec.describe Langchain::Assistant::LLM::Adapters::Ollama do
         )
       ).to eq({
         messages: [{role: "user", content: "Hello"}],
-        tools: Langchain::Tool::Calculator.function_schemas.to_openai_format
+        tools: [
+          {
+            function: {
+              description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+              name: "langchain_tool_calculator__execute",
+              parameters: {
+                properties: {
+                  input: {
+                    description: "Math expression",
+                    type: "string"
+                  }
+                },
+                required: ["input"],
+                type: "object"
+              }
+            },
+            type: "function"
+          }
+        ]
       })
     end
   end

--- a/spec/langchain/assistant/llm/adapters/ollama_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/ollama_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Langchain::Assistant::LLM::Adapters::Ollama do
+  let(:llm) { Langchain::LLM::Ollama.new(api_key: "123") }
+  subject { described_class.new(llm: llm) }
+
   describe "#build_chat_params" do
     it "returns the chat parameters" do
       expect(

--- a/spec/langchain/assistant/llm/adapters/openai_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/openai_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Langchain::Assistant::LLM::Adapters::OpenAI do
+  let(:llm) { Langchain::LLM::OpenAI.new(api_key: "123") }
+  subject { described_class.new(llm: llm) }
+
   describe "#build_chat_params" do
     it "returns the chat parameters" do
       expect(

--- a/spec/langchain/assistant/llm/adapters/openai_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/openai_spec.rb
@@ -13,7 +13,25 @@ RSpec.describe Langchain::Assistant::LLM::Adapters::OpenAI do
         )
       ).to eq({
         messages: [{role: "user", content: "Hello"}],
-        tools: Langchain::Tool::Calculator.function_schemas.to_openai_format,
+        tools: [
+          {
+            function: {
+              description: "Evaluates a pure math expression or if equation contains non-math characters (e.g.: \"12F in Celsius\") then it uses the google search calculator to evaluate the expression",
+              name: "langchain_tool_calculator__execute",
+              parameters: {
+                properties: {
+                  input: {
+                    description: "Math expression",
+                    type: "string"
+                  }
+                },
+                required: ["input"],
+                type: "object"
+              }
+            },
+            type: "function"
+          }
+        ],
         tool_choice: {"function" => {"name" => "langchain_tool_calculator__execute"}, "type" => "function"},
         parallel_tool_calls: false
       })

--- a/spec/tool_definition_spec.rb
+++ b/spec/tool_definition_spec.rb
@@ -236,20 +236,5 @@ RSpec.describe Langchain::ToolDefinition do
         expect(result.first[:function]).to be_a(Hash)
       end
     end
-
-    describe "#to_google_gemini_format" do
-      before do
-        function_schemas.add_function(method_name: :test_method, description: "Test description") do
-          property :test_prop, type: "string", description: "Test property"
-        end
-      end
-
-      it "returns an array of function schemas without the type key" do
-        result = function_schemas.to_google_gemini_format
-        expect(result).to be_an(Array)
-        expect(result.first).not_to have_key(:type)
-        expect(result.first[:name]).to eq("test_tool__test_method")
-      end
-    end
   end
 end

--- a/spec/tool_definition_spec.rb
+++ b/spec/tool_definition_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Langchain::ToolDefinition do
       end
     end
 
-    describe "#to_openai_format" do
+    describe "#functions" do
       before do
         function_schemas.add_function(method_name: :test_method, description: "Test description") do
           property :test_prop, type: "string", description: "Test property"
@@ -230,7 +230,7 @@ RSpec.describe Langchain::ToolDefinition do
       end
 
       it "returns an array of function schemas" do
-        result = function_schemas.to_openai_format
+        result = function_schemas.functions
         expect(result).to be_an(Array)
         expect(result.first[:type]).to eq("function")
         expect(result.first[:function]).to be_a(Hash)

--- a/spec/tool_definition_spec.rb
+++ b/spec/tool_definition_spec.rb
@@ -237,21 +237,6 @@ RSpec.describe Langchain::ToolDefinition do
       end
     end
 
-    describe "#to_anthropic_format" do
-      before do
-        function_schemas.add_function(method_name: :test_method, description: "Test description") do
-          property :test_prop, type: "string", description: "Test property"
-        end
-      end
-
-      it "returns an array of function schemas with input_schema instead of parameters" do
-        result = function_schemas.to_anthropic_format
-        expect(result).to be_an(Array)
-        expect(result.first).to have_key(:input_schema)
-        expect(result.first).not_to have_key(:parameters)
-      end
-    end
-
     describe "#to_google_gemini_format" do
       before do
         function_schemas.add_function(method_name: :test_method, description: "Test description") do


### PR DESCRIPTION
* Removed references to the private method in the Assistant’s specs
* Use the LLM adapter in the Assistant instance whenever possible, instead of calling LLM directly