### PR TITLE
Fix LLM adapter name error

### DIFF
--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -7,7 +7,10 @@ require "uri"
 require "json"
 
 loader = Zeitwerk::Loader.for_gem
+
 loader.ignore("#{__dir__}/langchainrb.rb")
+loader.ignore("#{__dir__}/langchain/assistants/llm")
+
 loader.inflector.inflect(
   "ai21" => "AI21",
   "ai21_response" => "AI21Response",


### PR DESCRIPTION
Fix https://github.com/patterns-ai-core/langchainrb/issues/816

- Update the **Gemfile.lock**
![CleanShot 2024-10-08 at 19 47 58](https://github.com/user-attachments/assets/92c4e698-a1f1-4d18-841c-75b1010ca564)

- Set `config.eager_load = true` in `config/environments/development.rb` 
- Puma works as normal
```
=> Booting Puma
=> Rails 7.2.0 application starting in development 
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 6.4.3 (ruby 3.3.4-p94) ("The Eagle of Durango")
*  Min threads: 5
*  Max threads: 5
*  Environment: development
*          PID: 46479
* Listening on http://127.0.0.1:3000
* Listening on http://[::1]:3000
Use Ctrl-C to stop
```