### PR TITLE
Fix issue with clearing instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## [Unreleased]
 - [BUGFIX] [https://github.com/patterns-ai-core/langchainrb/pull/837] Fix bug when tool functions with no input variables are used with Langchain::LLM::Anthropic
+- [BUGFIX] [https://github.com/patterns-ai-core/langchainrb/pull/836] Fix bug when assistant.instructions = nil did not remove the system message
 
 ## [0.18.0] - 2024-10-12
 - [BREAKING] Remove `Langchain::Assistant#clear_thread!` method

--- a/lib/langchain/assistant.rb
+++ b/lib/langchain/assistant.rb
@@ -196,7 +196,7 @@ module Langchain
 
       if @llm_adapter.support_system_message?
         # TODO: Should we still set a system message even if @instructions is "" or nil?
-        replace_system_message!(content: new_instructions) if @instructions
+        replace_system_message!(content: new_instructions)
       end
     end
 
@@ -217,6 +217,7 @@ module Langchain
     # @return [Array<Langchain::Message>] The messages
     def replace_system_message!(content:)
       messages.delete_if(&:system?)
+      return if content.nil?
 
       message = build_message(role: "system", content: content)
       messages.unshift(message)

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -482,6 +482,12 @@ RSpec.describe Langchain::Assistant do
         expect(subject.messages.first.content).to eq("New instructions")
         expect(subject.instructions).to eq("New instructions")
       end
+
+      it "clears instructions when instructions are nil" do
+        subject.instructions = nil
+        expect(subject.messages).to be_empty
+        expect(subject.instructions).to be_nil
+      end
     end
   end
 

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -484,6 +484,7 @@ RSpec.describe Langchain::Assistant do
       end
 
       it "clears instructions when instructions are nil" do
+        expect(subject.messages.find(&:system?).content).to eq(subject.instructions)
         subject.instructions = nil
         expect(subject.messages).to be_empty
         expect(subject.instructions).to be_nil


### PR DESCRIPTION
Previously, when instructions were assigned, setting them to `nil` did not fully clear the value. This commit resolves that issue.