### PR TITLE
Anthropic Tools: added default `input_schema` if no params

### DIFF
--- a/lib/langchain/tool_definition.rb
+++ b/lib/langchain/tool_definition.rb
@@ -103,6 +103,13 @@ module Langchain::ToolDefinition
     # @return [String] JSON string of schemas in Anthropic format
     def to_anthropic_format
       @schemas.values.map do |schema|
+        # Adds a default input_schema if no parameters are present
+        schema[:function][:parameters] ||= {
+          type: "object",
+          properties: {},
+          required: []
+        }
+
         schema[:function].transform_keys(parameters: :input_schema)
       end
     end


### PR DESCRIPTION
### Issue #826

This pull request addresses the issue where function schemas without parameters were causing errors when used with Anthropic. It ensures that a default empty `input_schema` is added when no parameters are present, aligning with [Anthropic's requirements](https://docs.anthropic.com/en/docs/build-with-claude/tool-use).