### PR TITLE
Allow passing Sequel connection options

### DIFF
--- a/lib/langchain/vectorsearch/pgvector.rb
+++ b/lib/langchain/vectorsearch/pgvector.rb
@@ -27,11 +27,11 @@ module Langchain::Vectorsearch
     # @param index_name [String] The name of the table to use for the index
     # @param llm [Object] The LLM client to use
     # @param namespace [String] The namespace to use for the index when inserting/querying
-    def initialize(url:, index_name:, llm:, namespace: nil)
+    def initialize(url:, index_name:, llm:, namespace: nil, connection_options: {})
       depends_on "sequel"
       depends_on "pgvector"
 
-      @db = Sequel.connect(url)
+      @db = Sequel.connect(url, connection_options)
 
       @table_name = index_name
 
@@ -57,7 +57,6 @@ module Langchain::Vectorsearch
       data = texts.zip(ids).flat_map do |(text, id)|
         {id: id, content: text, vectors: llm.embed(text: text).embedding.to_s, namespace: namespace}
       end
-      # @db[table_name.to_sym].multi_insert(data, return: :primary_key)
       @db[table_name.to_sym]
         .insert_conflict(
           target: :id,

--- a/spec/langchain/vectorsearch/pgvector_spec.rb
+++ b/spec/langchain/vectorsearch/pgvector_spec.rb
@@ -255,5 +255,22 @@ if ENV["POSTGRES_URL"]
         end
       end
     end
+
+    describe "#initialize" do
+      context "with connection options" do
+        it "creates a new instance with connection options passed to the db" do
+          custom_pgvector = Langchain::Vectorsearch::Pgvector.new(
+            url: ENV["POSTGRES_URL"],
+            index_name: "products",
+            llm: Langchain::LLM::OpenAI.new(api_key: "123"),
+            connection_options: {
+              max_connections: 10
+            }
+          )
+
+          expect(custom_pgvector.db.opts[:max_connections]).to eq(10)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #800 by allowing you to pass connection options to Sequel: 

```
Langchain::Vectorsearch::Pgvector.new(
  url: ENV["POSTGRES_URL"],
  index_name: "products",
  llm: Langchain::LLM::OpenAI.new(api_key: "123"),
  connection_options: {
    max_connections: 10
  }
)
```