### PR TITLE
Introducing Langchain.rb Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Available for paid consulting engagements! [Email me](mailto:andrei@sourcelabs.i
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/andreibondarev/langchainrb/blob/main/LICENSE.txt)
 [![](https://dcbadge.vercel.app/api/server/WDARp7J2n8?compact=true&style=flat)](https://discord.gg/WDARp7J2n8)
 [![X](https://img.shields.io/twitter/url/https/twitter.com/cloudposse.svg?style=social&label=Follow%20%40rushing_andrei)](https://twitter.com/rushing_andrei)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Langchain.rb%20Guru-006BFF)](https://gurubase.io/g/langchain-rb)
 
 ## Use Cases
 * Retrieval Augmented Generation (RAG) and vector search


### PR DESCRIPTION
Hello Langchain.rb team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Langchain.rb Guru](https://gurubase.io/g/langchain-rb) to Gurubase. Langchain.rb Guru uses the data from this repo and data from the [docs](https://rubydoc.info/gems/langchainrb) to answer questions by leveraging the LLM.

In this PR, I showcased the "Langchain.rb Guru" badge, which highlights that Langchain.rb now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Langchain.rb Guru in Gurubase, just let me know that's totally fine.
