### PR TITLE
Fix MistralAIMessage to handle "Tool" Output 

### DIFF
--- a/lib/langchain/assistant/messages/mistral_ai_message.rb
+++ b/lib/langchain/assistant/messages/mistral_ai_message.rb
@@ -53,20 +53,10 @@ module Langchain
             else
               h[:tool_call_id] = tool_call_id if tool_call_id
 
-              h[:content] = []
-
-              if content && !content.empty?
-                h[:content] << {
-                  type: "text",
-                  text: content
-                }
-              end
-
               if image_url
-                h[:content] << {
-                  type: "image_url",
-                  image_url: image_url
-                }
+                h[:content] = image_url
+              else
+                h[:content] = content
               end
             end
           end

--- a/lib/langchain/assistant/messages/mistral_ai_message.rb
+++ b/lib/langchain/assistant/messages/mistral_ai_message.rb
@@ -81,10 +81,10 @@ module Langchain
         # @return [Hash] The message as an MistralAI API-compatible hash, with the role as "assistant"
         def assistant_hash
           {
-            role: 'assistant',
+            role: "assistant",
             content: content,
             tool_calls: tool_calls,
-            prefix: false,
+            prefix: false
           }
         end
 
@@ -92,8 +92,8 @@ module Langchain
         # @return [Hash] The message as an MistralAI API-compatible hash, with the role as "system"
         def system_hash
           {
-            role: 'system',
-            content: build_content_array,
+            role: "system",
+            content: build_content_array
           }
         end
 
@@ -101,9 +101,9 @@ module Langchain
         # @return [Hash] The message as an MistralAI API-compatible hash, with the role as "tool"
         def tool_hash
           {
-            role: 'tool',
+            role: "tool",
             content: content,
-            tool_call_id: tool_call_id,
+            tool_call_id: tool_call_id
           }
         end
 
@@ -111,8 +111,8 @@ module Langchain
         # @return [Hash] The message as an MistralAI API-compatible hash, with the role as "user"
         def user_hash
           {
-            role: 'user',
-            content: build_content_array,
+            role: "user",
+            content: build_content_array
           }
         end
 

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -641,14 +641,14 @@ RSpec.describe Langchain::Assistant do
               messages: [
                 {role: "system", content: [{type: "text", text: instructions}]},
                 {role: "user", content: [{type: "text", text: "Please calculate 2+2"}]},
-                {role: "assistant", tool_calls: [
-                  {
-                    "function" => {"arguments" => "{\"input\":\"2+2\"}", "name" => "langchain_tool_calculator__execute"},
-                    "id" => "call_9TewGANaaIjzY31UCpAAGLeV",
-                    "type" => "function"
-                  }
+                {role: "assistant", prefix: false, content: '', tool_calls: [
+                    {
+                      "function" => {"arguments" => "{\"input\":\"2+2\"}", "name" => "langchain_tool_calculator__execute"},
+                      "id" => "call_9TewGANaaIjzY31UCpAAGLeV",
+                      "type" => "function"
+                    }
                 ]},
-                {content: [{type: "text", text: "4.0"}], role: "tool", tool_call_id: "call_9TewGANaaIjzY31UCpAAGLeV"}
+                {content: "4.0", role: "tool", tool_call_id: "call_9TewGANaaIjzY31UCpAAGLeV"}
               ],
               tools: calculator.class.function_schemas.to_openai_format,
               tool_choice: "auto"

--- a/spec/langchain/assistant/assistant_spec.rb
+++ b/spec/langchain/assistant/assistant_spec.rb
@@ -641,12 +641,12 @@ RSpec.describe Langchain::Assistant do
               messages: [
                 {role: "system", content: [{type: "text", text: instructions}]},
                 {role: "user", content: [{type: "text", text: "Please calculate 2+2"}]},
-                {role: "assistant", prefix: false, content: '', tool_calls: [
-                    {
-                      "function" => {"arguments" => "{\"input\":\"2+2\"}", "name" => "langchain_tool_calculator__execute"},
-                      "id" => "call_9TewGANaaIjzY31UCpAAGLeV",
-                      "type" => "function"
-                    }
+                {role: "assistant", prefix: false, content: "", tool_calls: [
+                  {
+                    "function" => {"arguments" => "{\"input\":\"2+2\"}", "name" => "langchain_tool_calculator__execute"},
+                    "id" => "call_9TewGANaaIjzY31UCpAAGLeV",
+                    "type" => "function"
+                  }
                 ]},
                 {content: "4.0", role: "tool", tool_call_id: "call_9TewGANaaIjzY31UCpAAGLeV"}
               ],

--- a/spec/langchain/assistant/messages/mistral_ai_message_spec.rb
+++ b/spec/langchain/assistant/messages/mistral_ai_message_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Langchain::Assistant::Messages::MistralAIMessage do
       let(:message) { described_class.new(role: "user", content: "Hello, world!", tool_calls: [], tool_call_id: nil) }
 
       it "returns a hash with the role and content key" do
-        expect(message.to_hash).to eq({role: "user", content: "Hello, world!"})
+        expect(message.to_hash).to eq({role: "user", content:  [{text: "Hello, world!", type: "text"}]})
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe Langchain::Assistant::Messages::MistralAIMessage do
       let(:message) { described_class.new(role: "assistant", tool_calls: [tool_call], tool_call_id: nil) }
 
       it "returns a hash with the tool_calls key" do
-        expect(message.to_hash).to eq({role: "assistant", tool_calls: [tool_call]})
+        expect(message.to_hash).to eq({role: "assistant", tool_calls: [tool_call], content: "", prefix: false})
       end
     end
 
@@ -42,7 +42,10 @@ RSpec.describe Langchain::Assistant::Messages::MistralAIMessage do
       it "returns a hash with the image_url key" do
         expect(message.to_hash).to eq({
           role: "user",
-          content: "https://example.com/image.jpg"
+          content: [
+            {text: "Please describe this image", type: "text"},
+            {image_url: "https://example.com/image.jpg", type: "image_url"}
+          ]
         })
       end
     end

--- a/spec/langchain/assistant/messages/mistral_ai_message_spec.rb
+++ b/spec/langchain/assistant/messages/mistral_ai_message_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Langchain::Assistant::Messages::MistralAIMessage do
       let(:message) { described_class.new(role: "user", content: "Hello, world!", tool_calls: [], tool_call_id: nil) }
 
       it "returns a hash with the role and content key" do
-        expect(message.to_hash).to eq({role: "user", content: [{type: "text", text: "Hello, world!"}]})
+        expect(message.to_hash).to eq({role: "user", content: "Hello, world!"})
       end
     end
 
@@ -18,7 +18,7 @@ RSpec.describe Langchain::Assistant::Messages::MistralAIMessage do
       let(:message) { described_class.new(role: "tool", content: "Hello, world!", tool_calls: [], tool_call_id: "123") }
 
       it "returns a hash with the tool_call_id key" do
-        expect(message.to_hash).to eq({role: "tool", content: [{type: "text", text: "Hello, world!"}], tool_call_id: "123"})
+        expect(message.to_hash).to eq({role: "tool", content: "Hello, world!", tool_call_id: "123"})
       end
     end
 
@@ -42,10 +42,7 @@ RSpec.describe Langchain::Assistant::Messages::MistralAIMessage do
       it "returns a hash with the image_url key" do
         expect(message.to_hash).to eq({
           role: "user",
-          content: [
-            {type: "text", text: "Please describe this image"},
-            {type: "image_url", image_url: "https://example.com/image.jpg"}
-          ]
+          content: "https://example.com/image.jpg"
         })
       end
     end

--- a/spec/langchain/assistant/messages/mistral_ai_message_spec.rb
+++ b/spec/langchain/assistant/messages/mistral_ai_message_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Langchain::Assistant::Messages::MistralAIMessage do
       let(:message) { described_class.new(role: "user", content: "Hello, world!", tool_calls: [], tool_call_id: nil) }
 
       it "returns a hash with the role and content key" do
-        expect(message.to_hash).to eq({role: "user", content:  [{text: "Hello, world!", type: "text"}]})
+        expect(message.to_hash).to eq({role: "user", content: [{text: "Hello, world!", type: "text"}]})
       end
     end
 


### PR DESCRIPTION
Solves: https://github.com/patterns-ai-core/langchainrb/issues/839

Breaks up hash by specific role following API Conventions

https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
Assistant
<img width="790" alt="image" src="https://github.com/user-attachments/assets/36058db7-752d-440f-8c06-0debd9a89333">

System
<img width="796" alt="image" src="https://github.com/user-attachments/assets/3985d0e1-2a96-40a8-becf-bb7e05d93a63">

Tool
<img width="755" alt="image" src="https://github.com/user-attachments/assets/364cd29a-f65b-4f4e-a106-f147e5eb7641">

User
<img width="777" alt="image" src="https://github.com/user-attachments/assets/b1a9d7f6-bbe0-44ff-bbf8-cbc616008ba1">


