### PR TITLE
Enhancement: Refactor for to_hash function in different messages class to be split by role

### DIFF
--- a/lib/langchain/assistant/messages/openai_message.rb
+++ b/lib/langchain/assistant/messages/openai_message.rb
@@ -50,32 +50,14 @@ module Langchain
         #
         # @return [Hash] The message as an OpenAI API-compatible hash
         def to_hash
-          {}.tap do |h|
-            h[:role] = role
-
-            if tool_calls.any?
-              h[:tool_calls] = tool_calls
-            else
-              h[:tool_call_id] = tool_call_id if tool_call_id
-
-              h[:content] = []
-
-              if content && !content.empty?
-                h[:content] << {
-                  type: "text",
-                  text: content
-                }
-              end
-
-              if image_url
-                h[:content] << {
-                  type: "image_url",
-                  image_url: {
-                    url: image_url
-                  }
-                }
-              end
-            end
+          if assistant?
+            assistant_hash
+          elsif system?
+            system_hash
+          elsif tool?
+            tool_hash
+          elsif user?
+            user_hash
           end
         end
 
@@ -98,6 +80,76 @@ module Langchain
         # @return [Boolean] true/false whether this message is a tool call
         def tool?
           role == "tool"
+        end
+
+        def user?
+          role == "user"
+        end
+
+        # Convert the message to an OpenAI API-compatible hash
+        # @return [Hash] The message as an OpenAI API-compatible hash, with the role as "assistant"
+        def assistant_hash
+          if tool_calls.any?
+            {
+              role: "assistant",
+              tool_calls: tool_calls
+            }
+          else
+            {
+              role: "assistant",
+              content: build_content_array
+            }
+          end
+        end
+
+        # Convert the message to an OpenAI API-compatible hash
+        # @return [Hash] The message as an OpenAI API-compatible hash, with the role as "system"
+        def system_hash
+          {
+            role: "system",
+            content: build_content_array
+          }
+        end
+
+        # Convert the message to an OpenAI API-compatible hash
+        # @return [Hash] The message as an OpenAI API-compatible hash, with the role as "tool"
+        def tool_hash
+          {
+            role: "tool",
+            tool_call_id: tool_call_id,
+            content: build_content_array
+          }
+        end
+
+        # Convert the message to an OpenAI API-compatible hash
+        # @return [Hash] The message as an OpenAI API-compatible hash, with the role as "user"
+        def user_hash
+          {
+            role: "user",
+            content: build_content_array
+          }
+        end
+
+        # Builds the content value for the message hash
+        # @return [Array<Hash>] An array of content hashes, with keys :type and :text or :image_url.
+        def build_content_array
+          content_details = []
+          if content && !content.empty?
+            content_details << {
+              type: "text",
+              text: content
+            }
+          end
+
+          if image_url
+            content_details << {
+              type: "image_url",
+              image_url: {
+                url: image_url
+              }
+            }
+          end
+          content_details
         end
       end
     end

--- a/spec/langchain/assistant/messages/openai_message_spec.rb
+++ b/spec/langchain/assistant/messages/openai_message_spec.rb
@@ -6,23 +6,46 @@ RSpec.describe Langchain::Assistant::Messages::OpenAIMessage do
   end
 
   describe "#to_hash" do
-    context "when role and content are not nil" do
-      let(:message) { described_class.new(role: "user", content: "Hello, world!", tool_calls: [], tool_call_id: nil) }
+    context "when role is user" do
+      let(:role) { "user" }
+      context "when image_url is present" do
+        let(:message) { described_class.new(role: "user", content: "Please describe this image", image_url: "https://example.com/image.jpg") }
+        it "returns a user_hash with the image_url key" do
+          expect(message.to_hash).to eq({
+            role: "user",
+            content: [
+              {type: "text", text: "Please describe this image"},
+              {type: "image_url", image_url: {url: "https://example.com/image.jpg"}}
+            ]
+          })
+        end
+      end
+      context "when image_url is absent" do
+        let(:message) { described_class.new(role: role, content: "Hello, how can I help you?") }
 
-      it "returns a hash with the role and content key" do
-        expect(message.to_hash).to eq({role: "user", content: [{type: "text", text: "Hello, world!"}]})
+        it "returns user_hash" do
+          described_class.new(role: role, content: "Hello, World")
+          expect(message).to receive(:to_hash).and_call_original
+          expect(message.to_hash).to eq({
+            role: "user",
+            content: [
+              {type: "text", text: "Hello, how can I help you?"}
+
+            ]
+          })
+        end
       end
     end
 
-    context "when tool_call_id is not nil" do
+    context "when role is tool" do
       let(:message) { described_class.new(role: "tool", content: "Hello, world!", tool_calls: [], tool_call_id: "123") }
 
-      it "returns a hash with the tool_call_id key" do
+      it "returns a tool_hash" do
         expect(message.to_hash).to eq({role: "tool", content: [{type: "text", text: "Hello, world!"}], tool_call_id: "123"})
       end
     end
 
-    context "when tool_calls is not empty" do
+    context "when role is assistant" do
       let(:tool_call) {
         {"id" => "call_9TewGANaaIjzY31UCpAAGLeV",
          "type" => "function",
@@ -31,22 +54,8 @@ RSpec.describe Langchain::Assistant::Messages::OpenAIMessage do
 
       let(:message) { described_class.new(role: "assistant", tool_calls: [tool_call], tool_call_id: nil) }
 
-      it "returns a hash with the tool_calls key" do
+      it "returns an assistant_hash" do
         expect(message.to_hash).to eq({role: "assistant", tool_calls: [tool_call]})
-      end
-    end
-
-    context "when image_url is present" do
-      let(:message) { described_class.new(role: "user", content: "Please describe this image", image_url: "https://example.com/image.jpg") }
-
-      it "returns a hash with the image_url key" do
-        expect(message.to_hash).to eq({
-          role: "user",
-          content: [
-            {type: "text", text: "Please describe this image"},
-            {type: "image_url", image_url: {url: "https://example.com/image.jpg"}}
-          ]
-        })
       end
     end
   end


### PR DESCRIPTION
Whats Changed:
- Refactored the to_hash function in the openai_message.rb, and google_gemini_message.rb  classes as per the issue https://github.com/patterns-ai-core/langchainrb/issues/856

