### PR TITLE
Add print to assistant_chat.rb example

### DIFF
--- a/examples/assistant_chat.rb
+++ b/examples/assistant_chat.rb
@@ -6,30 +6,21 @@ require "reline"
 # gem install reline
 # or add `gem "reline"` to your Gemfile
 
-openai = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
-assistant = Langchain::Assistant.new(
-  llm: openai,
-  instructions: "You are a Meteorologist Assistant that is able to pull the weather for any location",
-  tools: [
-    Langchain::Tool::Weather.new(api_key: ENV["OPEN_WEATHER_API_KEY"])
-  ]
-)
-
-DONE = %w[done end eof exit].freeze
-
-puts "Welcome to your Meteorological assistant!"
+DONE = %w[done end eof print exit].freeze
 
 def prompt_for_message
-  puts "(multiline input; type 'end' on its own line when done. or exit to exit)"
+  puts "\n(multiline input; type 'end' on its own line when done. or 'print' to print messages, or 'exit' to exit)\n\n"
 
-  user_message = Reline.readmultiline("Question: ", true) do |multiline_input|
+  user_message = Reline.readmultiline("Query: ", true) do |multiline_input|
     last = multiline_input.split.last
     DONE.include?(last)
   end
 
   return :noop unless user_message
+  return :print if user_message == "print"
 
   lines = user_message.split("\n")
+
   if lines.size > 1 && DONE.include?(lines.last)
     # remove the "done" from the message
     user_message = lines[0..-2].join("\n")
@@ -40,19 +31,54 @@ def prompt_for_message
   user_message
 end
 
+def print_messages(assistant)
+  puts "\n"
+  assistant.messages.each do |message|
+    puts "----"
+    puts message.role + " role content: " + message.content
+    case message.role
+    when "assistant"
+      message.tool_calls.each do |tool_call|
+        puts " " + tool_call["function"]["name"] + ": " << tool_call["function"]["arguments"]
+      end
+    when "tool"
+      puts " tool_call_id: " + message.tool_call_id
+    end
+  end
+  puts "-------"
+end
+
 begin
+  llm = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
+
+  # Or use local Ollama. See https://ollama.com/search?c=tools for models that support tools.
+  # llm = Langchain::LLM::Ollama.new(default_options: {chat_model: "mistral"})
+
+  assistant = Langchain::Assistant.new(
+    llm: llm,
+    instructions: "You are a Meteorologist Assistant that is able to report the weather for any city in metric units.",
+    tools: [
+      Langchain::Tool::Weather.new(api_key: ENV["OPEN_WEATHER_API_KEY"])
+    ]
+  )
+
+  puts "Welcome to your Meteorological assistant!"
+
   loop do
     user_message = prompt_for_message
 
     case user_message
     when :noop
       next
+    when :print
+      print_messages(assistant)
+      next
     when :exit
       break
     end
 
     assistant.add_message_and_run content: user_message, auto_tool_execution: true
-    puts assistant.messages.last.content
+    puts assistant.messages.last.content + "\n"
   end
 rescue Interrupt
   exit 0


### PR DESCRIPTION
Gives user ability to 'print' the assistants messages, which I found useful to better understand how the Assistant works and/or to test a tool.

Note that Ollama gives me a 404 error me even though there appears to be support for it, and it works from another application.
Shouldn't this work?
```ruby
  # Use local Ollama. See https://ollama.com/search?c=tools for models that support tools.
  llm = Langchain::LLM::Ollama.new(default_options: {chat_model: "mistral"})
```

```
Welcome to your Meteorological assistant!

(multiline input; type 'end' on its own line when done. or 'print' to print messages, or 'exit' to exit)

Query: Boston?
Query: end
D, [2024-11-10T06:27:11.902641 #34124] DEBUG -- [Langchain.rb]: Langchain::Assistant - Sending a call to Langchain::LLM::Ollama
W, [2024-11-10T06:27:11.902826 #34124]  WARN -- [Langchain.rb]: WARNING: `parallel_tool_calls:` is not supported by Ollama currently
W, [2024-11-10T06:27:11.902856 #34124]  WARN -- [Langchain.rb]: WARNING: `tool_choice:` is not supported by Ollama currently
I, [2024-11-10T06:27:11.904720 #34124]  INFO -- [request]: POST http://localhost:11434/api/chat
I, [2024-11-10T06:27:11.904778 #34124]  INFO -- [request]: User-Agent: "Faraday v2.12.0"
Content-Type: "application/json"
I, [2024-11-10T06:27:11.904804 #34124]  INFO -- [request]: {"messages":[{"role":"system","content":"You are a Meteorologist Assistant that is able to report the weather for any city in metric units."},{"role":"user","content":"Boston?"}],"model":"mistral","stream":false,"tools":[{"type":"function","function":{"name":"langchain_tool_weather__get_current_weather","description":"Returns current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string","description":"City name"},"state_code":{"type":"string","description":"State code"},"country_code":{"type":"string","description":"Country code"},"units":{"type":"string","description":"Units for temperature (imperial or metric). Default: \"imperial\"","enum":["imperial","metric","standard"]}},"required":["city","state_code"]}}}],"temperature":0.0}
I, [2024-11-10T06:27:11.909847 #34124]  INFO -- [response]: Status 404
I, [2024-11-10T06:27:11.909904 #34124]  INFO -- [response]: content-type: "application/json; charset=utf-8"
date: "Sun, 10 Nov 2024 11:27:11 GMT"
content-length: "61"
I, [2024-11-10T06:27:11.909932 #34124]  INFO -- [response]:
/Users/mattlindsey/.rvm/gems/ruby-3.2.1/gems/faraday-2.12.0/lib/faraday/response/raise_error.rb:30:in `on_complete': the server responded with status 404 (Faraday::ResourceNotFound)
	from /Users/mattlindsey/.rvm/gems/ruby-3.2.1/gems/faraday-2.12.0/lib/faraday/middleware.rb:57:in `block in call'
```

I do see it hitting it in the Ollama log:
```
[GIN] 2024/11/10 - 06:34:41 | 404 |     1.26275ms |       127.0.0.1 | POST     "/api/chat"