### PR TITLE
Langchain::Tool::Database#describe_table with COMMENT

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,6 +382,7 @@ GEM
     safe_ruby (1.0.4)
       childprocess (>= 0.3.9)
     sequel (5.87.0)
+      bigdecimal
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ GEM
     rubyzip (2.3.2)
     safe_ruby (1.0.4)
       childprocess (>= 0.3.9)
-    sequel (5.68.0)
+    sequel (5.87.0)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -480,7 +480,7 @@ DEPENDENCIES
   rubocop
   ruby-openai (~> 7.1.0)
   safe_ruby (~> 1.0.4)
-  sequel (~> 5.68.0)
+  sequel (~> 5.87.0)
   standard (>= 1.35.1)
   vcr
   weaviate-ruby (~> 0.9.2)

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -71,7 +71,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "roo-xls", "~> 1.2.0"
   spec.add_development_dependency "ruby-openai", "~> 7.1.0"
   spec.add_development_dependency "safe_ruby", "~> 1.0.4"
-  spec.add_development_dependency "sequel", "~> 5.68.0"
+  spec.add_development_dependency "sequel", "~> 5.87.0"
   spec.add_development_dependency "weaviate-ruby", "~> 0.9.2"
   spec.add_development_dependency "wikipedia-client", "~> 1.17.0"
   spec.add_development_dependency "power_point_pptx", "~> 0.1.0"

--- a/lib/langchain/tool/database.rb
+++ b/lib/langchain/tool/database.rb
@@ -5,7 +5,7 @@ module Langchain::Tool
   # Connects to a SQL database, executes SQL queries, and outputs DB schema for Agents to use
   #
   # Gem requirements:
-  #     gem "sequel", "~> 5.68.0"
+  #     gem "sequel", "~> 5.87.0"
   #
   # Usage:
   #     database = Langchain::Tool::Database.new(connection_string: "postgres://user:password@localhost:5432/db_name")
@@ -115,6 +115,7 @@ module Langchain::Tool
         else
           primary_key_columns << column[0]
         end
+        schema << " COMMENT '#{column[1][:comment]}'" if column[1][:comment]
         schema << ",\n" unless column == db.schema(table).last && primary_key_column_count == 1
       end
       if primary_key_column_count > 1

--- a/lib/langchain/vectorsearch/pgvector.rb
+++ b/lib/langchain/vectorsearch/pgvector.rb
@@ -6,7 +6,7 @@ module Langchain::Vectorsearch
     # The PostgreSQL vector search adapter
     #
     # Gem requirements:
-    #     gem "sequel", "~> 5.68.0"
+    #     gem "sequel", "~> 5.87.0"
     #     gem "pgvector", "~> 0.2"
     #
     # Usage:


### PR DESCRIPTION
Allows LLM to make use of columns' comments.
Possible since Sequel 5.87.0 ([PR](https://github.com/jeremyevans/sequel/pull/2249)).

## Example of usage:

Given this structure:

```sql
CREATE TABLE users(
  id integer PRIMARY KEY,
  name string COMMENT 'Internally known as 'foobar''
);
```

I can know ask things like `Give me the last registered user's foobar` to the LLM.