### PR TITLE
Allow o3-mini usage with tools

### DIFF
--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -25,6 +25,7 @@ module Langchain
               params[:tools] = build_tools(tools)
               params[:tool_choice] = build_tool_choice(tool_choice)
               # Temporary fix because OpenAI o1/o3/reasoning models don't support `parallel_tool_calls` parameter.
+              # Set `Assistant.new(parallel_tool_calls: nil, ...)` to avoid the error.
               params[:parallel_tool_calls] = parallel_tool_calls unless parallel_tool_calls.nil?
             end
             params

--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -24,6 +24,7 @@ module Langchain
             if tools.any?
               params[:tools] = build_tools(tools)
               params[:tool_choice] = build_tool_choice(tool_choice)
+              # Temporary fix because OpenAI o1/o3/reasoning models don't support `parallel_tool_calls` parameter.
               params[:parallel_tool_calls] = parallel_tool_calls unless parallel_tool_calls.nil?
             end
             params

--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -24,7 +24,7 @@ module Langchain
             if tools.any?
               params[:tools] = build_tools(tools)
               params[:tool_choice] = build_tool_choice(tool_choice)
-              params[:parallel_tool_calls] = parallel_tool_calls
+              params[:parallel_tool_calls] = parallel_tool_calls unless parallel_tool_calls.nil?
             end
             params
           end


### PR DESCRIPTION
OpenAI o3-mini model is fully compatible with tool calls, but selecting `chat_model: 'o3-mini'` and providing tools in a langchainrb assistant fails.

The error returned by OpenAI specifies that the `parallel_tool_calls` parameter is unsupported by the `o3` family models.
The error is a bit similar to: https://github.com/patterns-ai-core/langchainrb/issues/909 but instead of being about the `temperature` parameter, this one is about the `parallel_tool_calls`

On issue #909 users are able to circumvent the error by explicitly setting the `temperature` parameter to `nil`.
This workaround does not work for the `parallel_tool_calls` parameter: if a users sets it to `nil`, the parameter is still sent to OpenAI (with a `null` value) and OpenAI complains that `null` is not an allowed value for a boolean.

This PR changes the behavior so that if `parallel_tool_calls` parameter is set to `nil` no value is sent for it to OpenAI, mimicking the behavior of the `temperature` parameter.

This allows users to use the `o3` family model with tools successfully; as long as they also set the `parallel_tool_calls` parameter to `nil`:

```Ruby
openai = Langchain::LLM::OpenAI.new(
  api_key: ENV["OPENAI_API_KEY"],
  default_options: {
    temperature: nil,
    chat_model: "o3-mini",
  }
)
assistant = Langchain::Assistant.new(
  llm: openai,
  instructions: "You are a simple assistant that answers user questions",
  parallel_tool_calls: nil, # <------ Required to be nil for o3 family models
  tools: [
    Langchain::Tool::Wikipedia.new,
  ]
)
```

