### PR TITLE
Add support for Amazon Nova models

### DIFF
--- a/lib/langchain/llm/aws_bedrock.rb
+++ b/lib/langchain/llm/aws_bedrock.rb
@@ -25,7 +25,6 @@ module Langchain::LLM
     attr_reader :client, :defaults
 
     SUPPORTED_COMPLETION_PROVIDERS = %i[
-      amazon
       anthropic
       ai21
       cohere

--- a/lib/langchain/llm/response/aws_bedrock_amazon_response.rb
+++ b/lib/langchain/llm/response/aws_bedrock_amazon_response.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Langchain::LLM
+  class AwsBedrockAmazonResponse < BaseResponse
+    def completion
+      raw_response.dig("output", "message", "content", 0, "text")
+    end
+
+    def chat_completion
+      completion
+    end
+
+    def chat_completions
+      completions
+    end
+
+    def completions
+      nil
+    end
+
+    def stop_reason
+      raw_response.dig("stopReason")
+    end
+
+    def prompt_tokens
+      raw_response.dig("usage", "inputTokens").to_i
+    end
+
+    def completion_tokens
+      raw_response.dig("usage", "outputTokens").to_i
+    end
+
+    def total_tokens
+      raw_response.dig("usage", "totalTokens").to_i
+    end
+  end
+end

--- a/spec/langchain/llm/aws_bedrock_spec.rb
+++ b/spec/langchain/llm/aws_bedrock_spec.rb
@@ -119,6 +119,138 @@ RSpec.describe Langchain::LLM::AwsBedrock do
         end
       end
     end
+
+    context "with amazon nova pro provider" do
+      let(:response) do
+        {
+          output: {
+            message: {
+              content: [
+                {text: "The capital of France is Paris."}
+              ]
+            }
+          },
+          usage: {inputTokens: 14, outputTokens: 10}
+        }.to_json
+      end
+
+      let(:model_id) { "amazon.nova-pro-v1:0" }
+
+      before do
+        response_object = double("response_object")
+        allow(response_object).to receive(:body).and_return(StringIO.new(response))
+        allow(subject.client).to receive(:invoke_model)
+          .with(matching(
+            model_id:,
+            body: {
+              messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
+              inferenceConfig: {
+                maxTokens: 300
+              }
+            }.to_json,
+            content_type: "application/json",
+            accept: "application/json"
+          ))
+          .and_return(response_object)
+      end
+
+      it "returns a completion" do
+        expect(
+          subject.chat(
+            messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
+            model: model_id
+          ).chat_completion
+        ).to eq("The capital of France is Paris.")
+      end
+    end
+
+    context "with amazon nova lite provider" do
+      let(:response) do
+        {
+          output: {
+            message: {
+              content: [
+                {text: "The capital of France is Paris."}
+              ]
+            }
+          },
+          usage: {inputTokens: 14, outputTokens: 10}
+        }.to_json
+      end
+
+      let(:model_id) { "amazon.nova-lite-v1:0" }
+
+      before do
+        response_object = double("response_object")
+        allow(response_object).to receive(:body).and_return(StringIO.new(response))
+        allow(subject.client).to receive(:invoke_model)
+          .with(matching(
+            model_id:,
+            body: {
+              messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
+              inferenceConfig: {
+                maxTokens: 300
+              }
+            }.to_json,
+            content_type: "application/json",
+            accept: "application/json"
+          ))
+          .and_return(response_object)
+      end
+
+      it "returns a completion" do
+        expect(
+          subject.chat(
+            messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
+            model: model_id
+          ).chat_completion
+        ).to eq("The capital of France is Paris.")
+      end
+    end
+
+    context "with amazon nova micro provider" do
+      let(:response) do
+        {
+          output: {
+            message: {
+              content: [
+                {text: "The capital of France is Paris."}
+              ]
+            }
+          },
+          usage: {inputTokens: 14, outputTokens: 10}
+        }.to_json
+      end
+
+      let(:model_id) { "amazon.nova-micro-v1:0" }
+
+      before do
+        response_object = double("response_object")
+        allow(response_object).to receive(:body).and_return(StringIO.new(response))
+        allow(subject.client).to receive(:invoke_model)
+          .with(matching(
+            model_id:,
+            body: {
+              messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
+              inferenceConfig: {
+                maxTokens: 300
+              }
+            }.to_json,
+            content_type: "application/json",
+            accept: "application/json"
+          ))
+          .and_return(response_object)
+      end
+
+      it "returns a completion" do
+        expect(
+          subject.chat(
+            messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
+            model: model_id
+          ).chat_completion
+        ).to eq("The capital of France is Paris.")
+      end
+    end
   end
 
   describe "#complete" do

--- a/spec/langchain/llm/aws_bedrock_spec.rb
+++ b/spec/langchain/llm/aws_bedrock_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Langchain::LLM::AwsBedrock do
       end
     end
 
-    context "with amazon nova pro provider" do
+    context "with amazon provider" do
       let(:response) do
         {
           output: {
@@ -135,94 +135,6 @@ RSpec.describe Langchain::LLM::AwsBedrock do
       end
 
       let(:model_id) { "amazon.nova-pro-v1:0" }
-
-      before do
-        response_object = double("response_object")
-        allow(response_object).to receive(:body).and_return(StringIO.new(response))
-        allow(subject.client).to receive(:invoke_model)
-          .with(matching(
-            model_id:,
-            body: {
-              messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
-              inferenceConfig: {
-                maxTokens: 300
-              }
-            }.to_json,
-            content_type: "application/json",
-            accept: "application/json"
-          ))
-          .and_return(response_object)
-      end
-
-      it "returns a completion" do
-        expect(
-          subject.chat(
-            messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
-            model: model_id
-          ).chat_completion
-        ).to eq("The capital of France is Paris.")
-      end
-    end
-
-    context "with amazon nova lite provider" do
-      let(:response) do
-        {
-          output: {
-            message: {
-              content: [
-                {text: "The capital of France is Paris."}
-              ]
-            }
-          },
-          usage: {inputTokens: 14, outputTokens: 10}
-        }.to_json
-      end
-
-      let(:model_id) { "amazon.nova-lite-v1:0" }
-
-      before do
-        response_object = double("response_object")
-        allow(response_object).to receive(:body).and_return(StringIO.new(response))
-        allow(subject.client).to receive(:invoke_model)
-          .with(matching(
-            model_id:,
-            body: {
-              messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
-              inferenceConfig: {
-                maxTokens: 300
-              }
-            }.to_json,
-            content_type: "application/json",
-            accept: "application/json"
-          ))
-          .and_return(response_object)
-      end
-
-      it "returns a completion" do
-        expect(
-          subject.chat(
-            messages: [{role: "user", content: [{text: "What is the capital of France?"}]}],
-            model: model_id
-          ).chat_completion
-        ).to eq("The capital of France is Paris.")
-      end
-    end
-
-    context "with amazon nova micro provider" do
-      let(:response) do
-        {
-          output: {
-            message: {
-              content: [
-                {text: "The capital of France is Paris."}
-              ]
-            }
-          },
-          usage: {inputTokens: 14, outputTokens: 10}
-        }.to_json
-      end
-
-      let(:model_id) { "amazon.nova-micro-v1:0" }
 
       before do
         response_object = double("response_object")


### PR DESCRIPTION
## Purpose
Addresses #928 

## Approach
Add support for Amazon models in AwsBedrock and introduce AwsBedrockAmazonResponse.

## Testing
Ran against Nova Micro.
RSpec
