### PR TITLE
Remove prefixes for ids of aws inferences profiles

### DIFF
--- a/lib/langchain/llm/aws_bedrock.rb
+++ b/lib/langchain/llm/aws_bedrock.rb
@@ -167,7 +167,7 @@ module Langchain::LLM
 
     def parse_model_id(model_id)
       model_id
-        .gsub("us.", "") # Meta append "us." to their model ids
+        .gsub(/^(us|eu|apac|us-gov)\./, "") # Meta append "us." to their model ids, and AWS region prefixes are used by Bedrock cross-region model IDs.
         .split(".")
     end
 

--- a/spec/langchain/llm/aws_bedrock_spec.rb
+++ b/spec/langchain/llm/aws_bedrock_spec.rb
@@ -605,4 +605,36 @@ RSpec.describe Langchain::LLM::AwsBedrock do
       end
     end
   end
+
+  describe "#parse_model_id" do
+    it "strips the 'us.' prefix" do
+      input = "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+      result = subject.send(:parse_model_id, input)
+      expect(result).to eq(["anthropic", "claude-3-5-sonnet-20240620-v1:0"])
+    end
+
+    it "strips the 'eu.' prefix" do
+      input = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0"
+      result = subject.send(:parse_model_id, input)
+      expect(result).to eq(["anthropic", "claude-3-5-sonnet-20240620-v1:0"])
+    end
+
+    it "strips the 'apac.' prefix" do
+      input = "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
+      result = subject.send(:parse_model_id, input)
+      expect(result).to eq(["anthropic", "claude-3-5-sonnet-20240620-v1:0"])
+    end
+
+    it "strips the 'us-gov.' prefix" do
+      input = "us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0"
+      result = subject.send(:parse_model_id, input)
+      expect(result).to eq(["anthropic", "claude-3-5-sonnet-20240620-v1:0"])
+    end
+
+    it "returns the correct output when no region prefix is present" do
+      input = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+      result = subject.send(:parse_model_id, input)
+      expect(result).to eq(["anthropic", "claude-3-5-sonnet-20240620-v1:0"])
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes [Issue #944](https://github.com/patterns-ai-core/langchainrb/issues/944) by updating the parsing logic for AWS Bedrock model IDs. In inference scenarios, the model IDs can now include region prefixes such as `us.`, `eu.`, `apac.`, or `us-gov.`, which the system previously did not account for. As a result, valid IDs like `apac.anthropic.claude-3-5-sonnet-20240620-v1:0` were rejected even though they are correct.

## Changes

- **Updated `parse_model_id` Method**:  
  The method now uses a regular expression to strip any of the supported region prefixes from the model ID before splitting. This aligns with the prefixes defined in the [AWS Bedrock documentation,](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html) ensuring that the provider name is extracted correctly regardless of the prepended region.
  
  ```ruby
  def parse_model_id(model_id)
    model_id
      .gsub(/^(us|eu|apac|us-gov)\./, "")
      .split(".")
  end
  ```

- **Updated Tests**:  
  Additional tests have been added to cover the various possible prefixes (`us.`, `eu.`, `apac.`, and `us-gov.`) as well as the case when no prefix is present. This ensures that the method returns the correct values under different scenarios.

## Related Issue

- [[#944](https://github.com/patterns-ai-core/langchainrb/issues/944)](https://github.com/patterns-ai-core/langchainrb/issues/944)