### PR TITLE
Support ruby-anthropic gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,10 +46,6 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     afm (0.2.2)
     ai21 (0.2.1)
-    anthropic (0.3.2)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ast (2.4.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.992.0)
@@ -372,6 +368,10 @@ GEM
     rubocop-performance (1.21.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-anthropic (0.4.2)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     ruby-next (1.0.3)
       paco (~> 0.2)
       require-hooks (~> 0.2)
@@ -456,7 +456,6 @@ PLATFORMS
 
 DEPENDENCIES
   ai21 (~> 0.2.1)
-  anthropic (~> 0.3)
   aws-sdk-bedrockruntime (~> 1.1)
   chroma-db (~> 0.6.0)
   cohere-ruby (~> 0.9.10)
@@ -490,6 +489,7 @@ DEPENDENCIES
   roo-xls (~> 1.2.0)
   rspec (~> 3.0)
   rubocop
+  ruby-anthropic (~> 0.4)
   ruby-openai (~> 7.1.0)
   safe_ruby (~> 1.0.4)
   sequel (~> 5.87.0)

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
 
   # optional dependencies
   spec.add_development_dependency "ai21", "~> 0.2.1"
-  spec.add_development_dependency "anthropic", "~> 0.3"
+  spec.add_development_dependency "ruby-anthropic", "~> 0.4"
   spec.add_development_dependency "aws-sdk-bedrockruntime", "~> 1.1"
   spec.add_development_dependency "chroma-db", "~> 0.6.0"
   spec.add_development_dependency "cohere-ruby", "~> 0.9.10"

--- a/lib/langchain/llm/anthropic.rb
+++ b/lib/langchain/llm/anthropic.rb
@@ -25,7 +25,12 @@ module Langchain::LLM
     # @param default_options [Hash] Default options to use on every call to LLM, e.g.: { temperature:, completion_model:, chat_model:, max_tokens: }
     # @return [Langchain::LLM::Anthropic] Langchain::LLM::Anthropic instance
     def initialize(api_key:, llm_options: {}, default_options: {})
-      depends_on "anthropic"
+      begin
+        depends_on "ruby-anthropic", req: "anthropic"
+      rescue Langchain::DependencyHelper::LoadError
+        # Falls back to the older `anthropic` gem if `ruby-anthropic` gem cannot be loaded.
+        depends_on "anthropic"
+      end
 
       @client = ::Anthropic::Client.new(access_token: api_key, **llm_options)
       @defaults = DEFAULTS.merge(default_options)


### PR DESCRIPTION
This PR adds support for ruby-anthropic gem, which was renamed from anthropic gem.

> This gem has been renamed from `anthropic` to `ruby-anthropic`, to make way for the new [official Anthropic Ruby SDK](https://github.com/anthropics/anthropic-sdk-ruby) :tada: If you wish to keep using this gem, you just need to update your Gemfile from `anthropic` to `ruby-anthropic` and version `0.4.2` or greater. No other changes are needed and it will continue to work as normal.

https://github.com/alexrudall/ruby-anthropic/blob/v0.4.2/README.md

So, the anthropic gem was renamed to ruby-anthropic starting from version 0.4.2. If user is still using version 0.4.1 or earlier of the anthropic gem, the implementation falls back to anthropic instead of treating it as a load error.

The development dependency has been updated to use the new ruby-anthropic gem instead of the old anthropic gem.