### PR TITLE
Fix Assistant OpenAI adapter to handle message content structure returned by to_hash message method

### DIFF
--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -34,12 +34,19 @@ module Langchain
           # Build a OpenAI message
           #
           # @param role [String] The role of the message
-          # @param content [String] The content of the message
+          # @param content [String | Array<Hash>] The content of the message
           # @param image_url [String] The image URL
           # @param tool_calls [Array] The tool calls
           # @param tool_call_id [String] The tool call ID
           # @return [Messages::OpenAIMessage] The OpenAI message
           def build_message(role:, content: nil, image_url: nil, tool_calls: [], tool_call_id: nil)
+            if content.is_a?(Array)
+              content.each do |c|
+                content = c[:text] if c[:type] == "text"
+                image_url = c[:image_url][:url] if c[:type] == "image_url"
+              end
+            end
+
             Messages::OpenAIMessage.new(role: role, content: content, image_url: image_url, tool_calls: tool_calls, tool_call_id: tool_call_id)
           end
 

--- a/spec/langchain/assistant/llm/adapters/openai_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/openai_spec.rb
@@ -31,4 +31,33 @@ RSpec.describe Langchain::Assistant::LLM::Adapters::OpenAI do
       expect(subject.tool_role).to eq("tool")
     end
   end
+
+  describe "#build_message" do
+    context "when content is a string" do
+      it "returns the OpenAI message" do
+        expect(
+          subject.build_message(
+            role: "user",
+            content: "Hello",
+            image_url: "https://example.com/image.png",
+            tool_calls: [{"id" => "tool_call_id", "function" => {"name" => "langchain_tool_calculator__execute", "arguments" => "{\"a\": 1, \"b\": 2}"}}],
+            tool_call_id: "tool_call_id"
+          )
+        ).to have_attributes(role: "user", content: "Hello", image_url: "https://example.com/image.png", tool_calls: [{"id" => "tool_call_id", "function" => {"name" => "langchain_tool_calculator__execute", "arguments" => "{\"a\": 1, \"b\": 2}"}}], tool_call_id: "tool_call_id")
+      end
+    end
+
+    context "when content is an array" do
+      it "returns the OpenAI message" do
+        expect(
+          subject.build_message(
+            role: "user",
+            content: [{type: "text", text: "Hello"}, {type: "image_url", image_url: {url: "https://example.com/image.png"}}],
+            tool_calls: [{"id" => "tool_call_id", "function" => {"name" => "langchain_tool_calculator__execute", "arguments" => "{\"a\": 1, \"b\": 2}"}}],
+            tool_call_id: "tool_call_id"
+          )
+        ).to have_attributes(role: "user", content: "Hello", image_url: "https://example.com/image.png", tool_calls: [{"id" => "tool_call_id", "function" => {"name" => "langchain_tool_calculator__execute", "arguments" => "{\"a\": 1, \"b\": 2}"}}], tool_call_id: "tool_call_id")
+      end
+    end
+  end
 end


### PR DESCRIPTION
While using the gem for the first time I was discovering  `Langchain::Assistant` and experimenting with it.
While using naively I came across an issue : 

```ruby
@assistant = Langchain::Assistant.new(
  llm: Langchain::LLM::OpenAI.new(
	api_key: ENV['OPENAI_API_KEY'],
	default_options: {
	  temperature: 0.7,
	  chat_model: 'gpt-4o-mini'
	}
  ),
  instructions: "FOO BAR ZOO",
)
@assistant.add_message(content: "Foo bar Zoo") 
messages_hash = @assistant.messages.map(&:to_hash)
```

Here `message_hash` equal
```ruby
[{role: "system", content: [{type: "text", text: "FOO BAR ZOO"}]}, {role: "user", content: [{type: "text", text: "Foo bar Zoo"}]}]
```

From there I was thinking great I can just persist `messages_hash` somewhere and then use the method `@assistant.add_messages` to resume the conversation
But this happened : 

```ruby
@assistant.clear_messages!
@assistant.add_messages(messages: messages_hash)
resumed_hash = @assistant.messages.map(&:to_hash)
```
`resumed_hash` equal this
```ruby
[{role: "system", content: [{type: "text", text: "[{type: \"text\", text: \"FOO BAR ZOO\"}]"}]},
 {role: "user", content: [{type: "text", text: "[{type: \"text\", text: \"Foo bar Zoo\"}]"}]}]
```
The `message_hash` get stringified and nested into a new hash

After some investigation I found out that this behaviour comes from the function `build_message` at `/lib/langchain/assistant/llm/adapters/openai.rb:42`

```ruby
def build_message(role:, content: nil, image_url: nil, tool_calls: [], tool_call_id: nil)
	Messages::OpenAIMessage.new(role: role, content: content, image_url: image_url, tool_calls: tool_calls, tool_call_id: tool_call_id)
end

```
That ignore the fact that the method `to_hash`, from the same object, transform makes `content` into an hash that merge text message and image url

This PR is extracted from a monkey patch I made in my project :
```ruby
module Langchain
  class Assistant
    module LLM
      module Adapters
        class OpenAI < Base
          def build_message(role:, content: nil, image_url: nil, tool_calls: [], tool_call_id: nil)
            if content.is_a?(Array)
              content.each do |c|
                content = c[:text] if c[:type] == 'text'
                image_url = c[:image_url][:url] if c[:type] == 'image_url'
              end
            end
            Messages::OpenAIMessage.new(
              role: role,
              content: content,
              image_url: image_url,
              tool_calls: tool_calls,
              tool_call_id: tool_call_id
            )
          end
        end
      end
    end
  end
end
```
I also added tests for the `#build_message` that covers the previous behavior and the one added

