### PR TITLE
feat: Add support for Anthropic 'thinking' parameter

### DIFF
--- a/lib/langchain/llm/anthropic.rb
+++ b/lib/langchain/llm/anthropic.rb
@@ -22,7 +22,7 @@ module Langchain::LLM
     #
     # @param api_key [String] The API key to use
     # @param llm_options [Hash] Options to pass to the Anthropic client
-    # @param default_options [Hash] Default options to use on every call to LLM, e.g.: { temperature:, completion_model:, chat_model:, max_tokens: }
+    # @param default_options [Hash] Default options to use on every call to LLM, e.g.: { temperature:, completion_model:, chat_model:, max_tokens:, thinking: }
     # @return [Langchain::LLM::Anthropic] Langchain::LLM::Anthropic instance
     def initialize(api_key:, llm_options: {}, default_options: {})
       depends_on "anthropic"
@@ -34,7 +34,8 @@ module Langchain::LLM
         temperature: {default: @defaults[:temperature]},
         max_tokens: {default: @defaults[:max_tokens]},
         metadata: {},
-        system: {}
+        system: {},
+        thinking: {default: @defaults[:thinking]}
       )
       chat_parameters.ignore(:n, :user)
       chat_parameters.remap(stop: :stop_sequences)
@@ -97,6 +98,7 @@ module Langchain::LLM
     # @option params [String] :system System prompt
     # @option params [Float] :temperature Amount of randomness injected into the response
     # @option params [Array<String>] :tools Definitions of tools that the model may use
+    # @option params [Hash] :thinking Enable extended thinking mode, e.g. { type: "enabled", budget_tokens: 4000 }
     # @option params [Integer] :top_k Only sample from the top K options for each subsequent token
     # @option params [Float] :top_p Use nucleus sampling.
     # @return [Langchain::LLM::AnthropicResponse] The chat completion

--- a/spec/langchain/llm/anthropic_spec.rb
+++ b/spec/langchain/llm/anthropic_spec.rb
@@ -106,6 +106,30 @@ RSpec.describe Langchain::LLM::Anthropic do
       end
     end
 
+    context "with thinking parameter" do
+      let(:thinking_params) { {type: "enabled", budget_tokens: 4000} }
+
+      context "passed in default_options" do
+        subject { described_class.new(api_key: "123", default_options: {thinking: thinking_params}) }
+
+        it "includes thinking parameter in the request" do
+          expect(subject.client).to receive(:messages)
+            .with(parameters: hash_including(thinking: thinking_params))
+            .and_return(response)
+          subject.chat(messages: messages)
+        end
+      end
+
+      context "passed directly to chat method" do
+        it "includes thinking parameter in the request" do
+          expect(subject.client).to receive(:messages)
+            .with(parameters: hash_including(thinking: thinking_params))
+            .and_return(response)
+          subject.chat(messages: messages, thinking: thinking_params)
+        end
+      end
+    end
+
     context "with streaming" do
       let(:fixture) { File.read("spec/fixtures/llm/anthropic/chat_stream.json") }
       let(:response) { JSON.parse(fixture) }


### PR DESCRIPTION
This commit introduces support for the `thinking` parameter in the Anthropic LLM integration. Users can now enable Claude 3.7 Sonnet's extended thinking mode by passing the `thinking` parameter either via `default_options` during initialization or directly to the `chat` method.

Changes include:
- Added `thinking` to the `chat_parameters` schema in `Langchain::LLM::Anthropic`.
- Included tests for the `thinking` parameter in `spec/langchain/llm/anthropic_spec.rb`.
- Updated inline documentation for the `initialize` and `chat` methods to reflect the new parameter.