### PR TITLE
Pass the metadata to the openai call

### DIFF
--- a/lib/langchain/assistant.rb
+++ b/lib/langchain/assistant.rb
@@ -47,6 +47,7 @@ module Langchain
       # Callbacks
       add_message_callback: nil,
       tool_execution_callback: nil,
+      metadata: nil,
       &block
     )
       unless tools.is_a?(Array) && tools.all? { |tool| tool.class.singleton_class.included_modules.include?(Langchain::ToolDefinition) }
@@ -70,6 +71,8 @@ module Langchain
       @total_prompt_tokens = 0
       @total_completion_tokens = 0
       @total_tokens = 0
+
+      @metadata = metadata
     end
 
     # Add a user message to the messages array
@@ -343,7 +346,8 @@ module Langchain
         messages: array_of_message_hashes,
         tools: @tools,
         tool_choice: tool_choice,
-        parallel_tool_calls: parallel_tool_calls
+        parallel_tool_calls: parallel_tool_calls,
+        metadata: @metadata
       )
       @llm.chat(**params, &@block)
     end

--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -18,9 +18,10 @@ module Langchain
             instructions:,
             tools:,
             tool_choice:,
-            parallel_tool_calls:
+            parallel_tool_calls:,
+            metadata:
           )
-            params = {messages: messages}
+            params = {messages: messages, metadata: metadata}
             if tools.any?
               params[:tools] = build_tools(tools)
               params[:tool_choice] = build_tool_choice(tool_choice)

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -118,6 +118,7 @@ module Langchain::LLM
     # @option params [String] :model ID of the model to use
     def chat(params = {}, &block)
       parameters = chat_parameters.to_params(params)
+      parameters[:metadata] = params[:metadata] if params[:metadata]
 
       raise ArgumentError.new("messages argument is required") if Array(parameters[:messages]).empty?
       raise ArgumentError.new("model argument is required") if parameters[:model].to_s.empty?


### PR DESCRIPTION
This allows us to pass metadata to the openai logs (it is a standard part of the API but this gem did not have support for it)

![Screenshot 2025-04-28 at 10 52 52](https://github.com/user-attachments/assets/52056ef8-a00a-4b9b-ae7e-d44c6113355c)
