### PR TITLE
Use `require_relative`

### DIFF
--- a/lib/langchainrb.rb
+++ b/lib/langchainrb.rb
@@ -1,1 +1,1 @@
-require "langchain"
+require_relative "langchain"


### PR DESCRIPTION
If there are many searches in the `$LOAD_PATH` in the user environment, require will perform unnecessary searches that are not needed. In contrast, `require_relative` is efficient because it uses a relative path.

Langchain.rb requires Ruby 3.1+, it is possible to use `require_relative`, which was introduced in Ruby 1.9:
https://github.com/patterns-ai-core/langchainrb/blob/0.19.4/langchain.gemspec#L15