### PR TITLE
Enable `Langchain::Tool::RubyCodeInterpreter` on Ruby 3.3+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,8 @@ GEM
     bigdecimal (3.1.8)
     builder (3.3.0)
     byebug (12.0.0)
-    childprocess (5.0.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     chroma-db (0.6.0)
       dry-monads (~> 1.6)
       ruby-next (>= 0.15.0)
@@ -386,8 +387,8 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     rubyzip (2.3.2)
-    safe_ruby (1.0.4)
-      childprocess (>= 0.3.9)
+    safe_ruby (1.0.5)
+      childprocess (~> 5)
     securerandom (0.4.1)
     sequel (5.87.0)
       bigdecimal
@@ -486,7 +487,7 @@ DEPENDENCIES
   rubocop
   ruby-anthropic (~> 0.4)
   ruby-openai (~> 7.1.0)
-  safe_ruby (~> 1.0.4)
+  safe_ruby (~> 1.0.5)
   sequel (~> 5.87.0)
   standard (>= 1.35.1)
   vcr

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "roo", "~> 2.10.0"
   spec.add_development_dependency "roo-xls", "~> 1.2.0"
   spec.add_development_dependency "ruby-openai", "~> 7.1.0"
-  spec.add_development_dependency "safe_ruby", "~> 1.0.4"
+  spec.add_development_dependency "safe_ruby", "~> 1.0.5"
   spec.add_development_dependency "sequel", "~> 5.87.0"
   spec.add_development_dependency "weaviate-ruby", "~> 0.9.2"
   spec.add_development_dependency "wikipedia-client", "~> 1.17.0"

--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -29,10 +29,6 @@ loader.inflector.inflect(
 
 loader.collapse("#{__dir__}/langchain/llm/response")
 
-# RubyCodeInterpreter does not work with Ruby 3.3;
-# https://github.com/ukutaht/safe_ruby/issues/4
-loader.ignore("#{__dir__}/langchain/tool/ruby_code_interpreter") if RUBY_VERSION >= "3.3.0"
-
 loader.setup
 
 # Langchain.rb a is library for building LLM-backed Ruby applications. It is an abstraction layer that sits on top of the emerging AI-related tools that makes it easy for developers to consume and string those services together.

--- a/lib/langchain/tool/ruby_code_interpreter.rb
+++ b/lib/langchain/tool/ruby_code_interpreter.rb
@@ -5,7 +5,7 @@ module Langchain::Tool
   # A tool that execute Ruby code in a sandboxed environment.
   #
   # Gem requirements:
-  #     gem "safe_ruby", "~> 1.0.4"
+  #     gem "safe_ruby", "~> 1.0.5"
   #
   # Usage:
   #    interpreter = Langchain::Tool::RubyCodeInterpreter.new

--- a/spec/langchain/tool/ruby_code_interpreter_spec.rb
+++ b/spec/langchain/tool/ruby_code_interpreter_spec.rb
@@ -1,29 +1,25 @@
 # frozen_string_literal: true
 
-# RubyCodeInterpreter does not work with Ruby 3.3;
-# https://github.com/ukutaht/safe_ruby/issues/4
-if RUBY_VERSION <= "3.2"
-  RSpec.describe Langchain::Tool::RubyCodeInterpreter do
-    describe "#execute" do
-      it "executes the expression" do
-        response = subject.execute(input: '"hello world".reverse!')
-        expect(response).to be_a(Langchain::ToolResponse)
-        expect(response.content).to eq("dlrow olleh")
-      end
+RSpec.describe Langchain::Tool::RubyCodeInterpreter do
+  describe "#execute" do
+    it "executes the expression" do
+      response = subject.execute(input: '"hello world".reverse!')
+      expect(response).to be_a(Langchain::ToolResponse)
+      expect(response.content).to eq("dlrow olleh")
+    end
 
-      it "executes a more complicated expression" do
-        code = <<~CODE
-          def reverse(string)
-            string.reverse!
-          end
+    it "executes a more complicated expression" do
+      code = <<~CODE
+        def reverse(string)
+          string.reverse!
+        end
 
-          reverse('hello world')
-        CODE
+        reverse('hello world')
+      CODE
 
-        response = subject.execute(input: code)
-        expect(response).to be_a(Langchain::ToolResponse)
-        expect(response.content).to eq("dlrow olleh")
-      end
+      response = subject.execute(input: code)
+      expect(response).to be_a(Langchain::ToolResponse)
+      expect(response.content).to eq("dlrow olleh")
     end
   end
 end


### PR DESCRIPTION
safe_ruby has supported Ruby 3.3+ since version 1.0.5: https://github.com/ukutaht/safe_ruby/issues/4#issuecomment-2393259226

## Before (using safe_ruby 1.0.4)

A `NameError` occurred when running under Ruby 3.3:

```console
$ ruby -v
ruby 3.3.8 (2025-04-09 revision b200bad6cd) [x86_64-darwin24]
$ bundle exec ruby -rlangchain -e "Langchain::Tool::RubyCodeInterpreter.new.execute(input: '[1, 2, 3].map{ |n| n + 1 }')"
D, [2025-05-01T00:15:18.396619 #61580] DEBUG -- [Langchain.rb]: Langchain::Tool::RubyCodeInterpreter - Executing "[1, 2, 3].map{ |n| n + 1 }"
/Users/koic/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/safe_ruby-1.0.4/lib/safe_ruby/runner.rb:45:
in `rescue in eval': /var/folders/6j/5l8q3y250b97529_tcssrwlm0000gn/T/saferuby20250430-90315-4c2rkb:17:
in `undef_method': undefined method `new' for class `String' (NameError) (RuntimeError)

    klass.send(:undef_method, method)
         ^^^^^
Did you mean?  next
        from /var/folders/6j/5l8q3y250b97529_tcssrwlm0000gn/T/saferuby20250430-90315-4c2rkb:17:in `block in keep_methods'
        from /var/folders/6j/5l8q3y250b97529_tcssrwlm0000gn/T/saferuby20250430-90315-4c2rkb:16:in `each'
        from /var/folders/6j/5l8q3y250b97529_tcssrwlm0000gn/T/saferuby20250430-90315-4c2rkb:16:in `keep_methods'
        from /var/folders/6j/5l8q3y250b97529_tcssrwlm0000gn/T/saferuby20250430-90315-4c2rkb:37:in `<main>'

        from /Users/koic/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/safe_ruby-1.0.4/lib/safe_ruby/runner.rb:41:in `eval'
        from /Users/koic/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/safe_ruby-1.0.4/lib/safe_ruby/runner.rb:20:in `eval'
        from /Users/koic/src/github.com/patterns-ai-core/langchainrb/lib/langchain/tool/ruby_code_interpreter.rb:38:in `safe_eval'
        from /Users/koic/src/github.com/patterns-ai-core/langchainrb/lib/langchain/tool/ruby_code_interpreter.rb:34:in `execute'
        from -e:1:in `<main>'
<internal:marshal>:34:in `load': incompatible marshal file format (can't be read) (TypeError)
        format version 4.8 required; 47.118 given
        from /Users/koic/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/safe_ruby-1.0.4/lib/safe_ruby/runner.rb:42:in `eval'
        from /Users/koic/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/safe_ruby-1.0.4/lib/safe_ruby/runner.rb:20:in `eval'
        from /Users/koic/src/github.com/patterns-ai-core/langchainrb/lib/langchain/tool/ruby_code_interpreter.rb:38:in `safe_eval'
        from /Users/koic/src/github.com/patterns-ai-core/langchainrb/lib/langchain/tool/ruby_code_interpreter.rb:34:in `execute'
        from -e:1:in `<main>'
```

## After (using safe_ruby 1.0.5)

No error occurs:

```console
$ ruby -v
ruby 3.3.8 (2025-04-09 revision b200bad6cd) [x86_64-darwin24]
$ bundle exec ruby -rlangchain -e "Langchain::Tool::RubyCodeInterpreter.new.execute(input: '[1, 2, 3].map{ |n| n + 1 }')"
D, [2025-05-01T00:16:09.404532 #63102] DEBUG -- [Langchain.rb]: Langchain::Tool::RubyCodeInterpreter - Executing "[1, 2, 3].map{ |n| n + 1 }"
```

Ruby 3.4 works as well.