### PR TITLE
Refine warning behavior for unsupported options

### DIFF
--- a/lib/langchain/assistant/llm/adapters/aws_bedrock_anthropic.rb
+++ b/lib/langchain/assistant/llm/adapters/aws_bedrock_anthropic.rb
@@ -10,9 +10,9 @@ module Langchain
           # @param [String] choice
           # @param [Boolean] _parallel_tool_calls
           # @return [Hash]
-          def build_tool_choice(choice, _parallel_tool_calls)
+          def build_tool_choice(choice, parallel_tool_calls)
             # Aws Bedrock hosted Anthropic does not support parallel tool calls
-            Langchain.logger.warn "WARNING: parallel_tool_calls is not supported by AWS Bedrock Anthropic currently"
+            Langchain.logger.warn "WARNING: parallel_tool_calls is not supported by AWS Bedrock Anthropic currently" if parallel_tool_calls
 
             tool_choice_object = {}
 

--- a/lib/langchain/assistant/llm/adapters/google_gemini.rb
+++ b/lib/langchain/assistant/llm/adapters/google_gemini.rb
@@ -20,7 +20,7 @@ module Langchain
             tool_choice:,
             parallel_tool_calls:
           )
-            Langchain.logger.warn "WARNING: `parallel_tool_calls:` is not supported by Google Gemini currently"
+            Langchain.logger.warn "WARNING: `parallel_tool_calls:` is not supported by Google Gemini currently" if parallel_tool_calls
 
             params = {messages: messages}
             if tools.any?

--- a/lib/langchain/assistant/llm/adapters/mistral_ai.rb
+++ b/lib/langchain/assistant/llm/adapters/mistral_ai.rb
@@ -20,7 +20,7 @@ module Langchain
             tool_choice:,
             parallel_tool_calls:
           )
-            Langchain.logger.warn "WARNING: `parallel_tool_calls:` is not supported by Mistral AI currently"
+            Langchain.logger.warn "WARNING: `parallel_tool_calls:` is not supported by Mistral AI currently" if parallel_tool_calls
 
             params = {messages: messages}
             if tools.any?

--- a/lib/langchain/assistant/llm/adapters/ollama.rb
+++ b/lib/langchain/assistant/llm/adapters/ollama.rb
@@ -20,8 +20,8 @@ module Langchain
             tool_choice:,
             parallel_tool_calls:
           )
-            Langchain.logger.warn "WARNING: `parallel_tool_calls:` is not supported by Ollama currently"
-            Langchain.logger.warn "WARNING: `tool_choice:` is not supported by Ollama currently"
+            Langchain.logger.warn "WARNING: `parallel_tool_calls:` is not supported by Ollama currently" if parallel_tool_calls
+            Langchain.logger.warn "WARNING: `tool_choice:` is not supported by Ollama currently" if tool_choice
 
             params = {messages: messages}
             if tools.any?

--- a/spec/langchain/assistant/llm/adapters/aws_bedrock_anthropic_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/aws_bedrock_anthropic_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Langchain::Assistant::LLM::Adapters::AwsBedrockAnthropic do
   describe "#build_tool_choice" do
     it "returns the tool choice object with 'auto'" do
-      expect(subject.send(:build_tool_choice, "auto", true)).to eq({type: "auto"})
+      expect(subject.send(:build_tool_choice, "auto", false)).to eq({type: "auto"})
     end
 
     it "returns the tool choice object with selected tool function" do

--- a/spec/langchain/assistant/llm/adapters/ollama_spec.rb
+++ b/spec/langchain/assistant/llm/adapters/ollama_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Langchain::Assistant::LLM::Adapters::Ollama do
           messages: [{role: "user", content: "Hello"}],
           instructions: "Instructions",
           tools: [Langchain::Tool::Calculator.new],
-          tool_choice: "langchain_tool_calculator__execute",
+          tool_choice: nil,
           parallel_tool_calls: false
         )
       ).to eq({


### PR DESCRIPTION
## Summary

Currently, the warning for unsupported options is shown regardless of whether an explicit value is provided.

This PR updates the behavior so that the warning is shown only when the unsupported options is explicitly set by the user.

Tests have been updated to reflect usage without warnings, which is what users would expect.

## Additional Information

Note that `parallel_tool_calls` option in `Langchain::Assistant#initialize` defaults to `true`: https://github.com/patterns-ai-core/langchainrb/blob/0.19.5/lib/langchain/assistant.rb#L45

However, whether this option is supported depends on the underlying LLM. Therefore, for LLMs that do not support `parallel_tool_calls`, the option should effectively not be `true`.

Since this would involve changing the default behavior of `parallel_tool_calls`, it is considered out of scope for this PR and should be addressed separately.