### PR TITLE
Fix default embedding dimension for `Langchain::LLM::Ollama` using llama3.2

### DIFF
--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -24,7 +24,7 @@ module Langchain::LLM
       llama2: 4_096,
       llama3: 4_096,
       "llama3.1": 4_096,
-      "llama3.2": 4_096,
+      "llama3.2": 3_072,
       llava: 4_096,
       mistral: 4_096,
       "mistral-openorca": 4_096,


### PR DESCRIPTION
This PR updates the default value of `Langchain::LLM::Ollama#llm.default_dimensions`.

For the default `llama3.2` (3B) model installed via `ollama`, the output of `ollama show` indicates that the "embedding length" is 3072:

```console
$ ollama show llama3.2
  Model
    architecture        llama
    parameters          3.2B
    context length      131072
    embedding length    3072
    quantization        Q4_K_M

  Capabilities
    completion
    tools

  Parameters
    stop    "<|start_header_id|>"
    stop    "<|end_header_id|>"
    stop    "<|eot_id|>"

  License
    LLAMA 3.2 COMMUNITY LICENSE AGREEMENT
    Llama 3.2 Version Release Date: September 25, 2024
```

Additionally, the official Ollama page for llama3.2 also indicates `llama.embedding_length` is 3072. https://ollama.com/library/llama3.2/blobs/dde5aa3fc5ff

Based on these observations, this PR updates the default embedding dimension to 3072.

Fixes #959.