### PR TITLE
Bump ruby-openai to 8.1.0 to suppress a warning

### DIFF
--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "qdrant-ruby", "~> 0.9.8"
   spec.add_development_dependency "roo", "~> 2.10.0"
   spec.add_development_dependency "roo-xls", "~> 1.2.0"
-  spec.add_development_dependency "ruby-openai", "~> 7.1.0"
+  spec.add_development_dependency "ruby-openai", "~> 8.1.0"
   spec.add_development_dependency "safe_ruby", "~> 1.0.5"
   spec.add_development_dependency "sequel", "~> 5.87.0"
   spec.add_development_dependency "weaviate-ruby", "~> 0.9.2"


### PR DESCRIPTION
This PR bumps ruby-openai to 8.1.0+ to suppress the following ruby-openai's warning:

```console
$ RUBYOPT=-w bundle exec rspec spec/langchain/llm/openai_spec.rb
/Users/koic/.rbenv/versions/3.2.5/lib/ruby/gems/3.2.0/gems/ruby-openai-7.1.0/lib/openai/client.rb:15:
warning: `*' interpreted as argument prefix
```

This update includes the following patch to address the issue: https://github.com/alexrudall/ruby-openai/pull/576