### PR TITLE
Update Pinecone Ruby Client to 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ You can instantiate any other supported vector search database:
 client = Langchain::Vectorsearch::Chroma.new(...)   # `gem "chroma-db", "~> 0.6.0"`
 client = Langchain::Vectorsearch::Hnswlib.new(...)  # `gem "hnswlib", "~> 0.8.1"`
 client = Langchain::Vectorsearch::Milvus.new(...)   # `gem "milvus", "~> 0.9.3"`
-client = Langchain::Vectorsearch::Pinecone.new(...) # `gem "pinecone", "~> 0.1.6"`
+client = Langchain::Vectorsearch::Pinecone.new(...) # `gem "pinecone", "~> 1.0"`
 client = Langchain::Vectorsearch::Pgvector.new(...) # `gem "pgvector", "~> 0.2"`
 client = Langchain::Vectorsearch::Qdrant.new(...)   # `gem "qdrant-ruby", "~> 0.9.3"`
 client = Langchain::Vectorsearch::Elasticsearch.new(...)   # `gem "elasticsearch", "~> 8.2.0"`

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -63,7 +63,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pg", "~> 1.5"
   spec.add_development_dependency "pgvector", "~> 0.2.1"
   spec.add_development_dependency "pdf-reader", "~> 2.0"
-  spec.add_development_dependency "pinecone", "~> 0.1.6"
+  spec.add_development_dependency "pinecone", "~> 1.0"
   spec.add_development_dependency "replicate-ruby", "~> 0.2.2"
   spec.add_development_dependency "qdrant-ruby", "~> 0.9.8"
   spec.add_development_dependency "roo", "~> 2.10.0"

--- a/lib/langchain/vectorsearch/pinecone.rb
+++ b/lib/langchain/vectorsearch/pinecone.rb
@@ -5,7 +5,7 @@ module Langchain::Vectorsearch
   # Wrapper around Pinecone API.
   #
   # Gem requirements:
-  #     gem "pinecone", "~> 0.1.6"
+  #     gem "pinecone", "~> 0.1"
   #
   # Usage:
   #     pinecone = Langchain::Vectorsearch::Pinecone.new(environment:, api_key:, index_name:, llm:)


### PR DESCRIPTION
This PR updates Pinecone Ruby Client to 1.x to use Pinecone V2 API.

Pinecone 1.1 has already been released:
https://github.com/ScotterC/pinecone/blob/main/CHANGELOG.md

So this change sets the development dependency to `"~> 1.0"` to enable testing within the 1.x series. As noted in issue #662, users are likely specifying `"~> 1.0"` in their Gemfile, so this version constraint is chosen to allow compatibility with minor updates.

Closes #662.