### PR TITLE
[Doc] Move `Langchain::Vectorsearch` class documentation to correct locations

### DIFF
--- a/lib/langchain/vectorsearch/chroma.rb
+++ b/lib/langchain/vectorsearch/chroma.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 module Langchain::Vectorsearch
+  #
+  # Wrapper around Chroma DB
+  #
+  # Gem requirements:
+  #     gem "chroma-db", "~> 0.6.0"
+  #
+  # Usage:
+  #     chroma = Langchain::Vectorsearch::Chroma.new(url:, index_name:, llm:, api_key: nil)
+  #
   class Chroma < Base
-    #
-    # Wrapper around Chroma DB
-    #
-    # Gem requirements:
-    #     gem "chroma-db", "~> 0.6.0"
-    #
-    # Usage:
-    # chroma = Langchain::Vectorsearch::Chroma.new(url:, index_name:, llm:, api_key: nil)
-    #
-
     # Initialize the Chroma client
     # @param url [String] The URL of the Chroma server
     # @param index_name [String] The name of the index to use

--- a/lib/langchain/vectorsearch/elasticsearch.rb
+++ b/lib/langchain/vectorsearch/elasticsearch.rb
@@ -1,34 +1,34 @@
 # frozen_string_literal: true
 
 module Langchain::Vectorsearch
+  #
+  # Wrapper around Elasticsearch vector search capabilities.
+  #
+  # Setting up Elasticsearch:
+  # 1. Get Elasticsearch up and running with Docker: https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
+  # 2. Copy the HTTP CA certificate SHA-256 fingerprint and set the ELASTICSEARCH_CA_FINGERPRINT environment variable
+  # 3. Set the ELASTICSEARCH_URL environment variable
+  #
+  # Gem requirements:
+  #     gem "elasticsearch", "~> 8.0.0"
+  #
+  # Usage:
+  #     llm = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
+  #     es = Langchain::Vectorsearch::Elasticsearch.new(
+  #       url: ENV["ELASTICSEARCH_URL"],
+  #       index_name: "docs",
+  #       llm: llm,
+  #       es_options: {
+  #         transport_options: {ssl: {verify: false}},
+  #         ca_fingerprint: ENV["ELASTICSEARCH_CA_FINGERPRINT"]
+  #       }
+  #     )
+  #
+  #     es.create_default_schema
+  #     es.add_texts(texts: ["..."])
+  #     es.similarity_search(text: "...")
+  #
   class Elasticsearch < Base
-    #
-    # Wrapper around Elasticsearch vector search capabilities.
-    #
-    # Setting up Elasticsearch:
-    # 1. Get Elasticsearch up and running with Docker: https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
-    # 2. Copy the HTTP CA certificate SHA-256 fingerprint and set the ELASTICSEARCH_CA_FINGERPRINT environment variable
-    # 3. Set the ELASTICSEARCH_URL environment variable
-    #
-    # Gem requirements:
-    #     gem "elasticsearch", "~> 8.0.0"
-    #
-    # Usage:
-    #     llm = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
-    #     es = Langchain::Vectorsearch::Elasticsearch.new(
-    #       url: ENV["ELASTICSEARCH_URL"],
-    #       index_name: "docs",
-    #       llm: llm,
-    #       es_options: {
-    #         transport_options: {ssl: {verify: false}},
-    #         ca_fingerprint: ENV["ELASTICSEARCH_CA_FINGERPRINT"]
-    #       }
-    #     )
-    #
-    #     es.create_default_schema
-    #     es.add_texts(texts: ["..."])
-    #     es.similarity_search(text: "...")
-    #
     attr_accessor :es_client, :index_name, :options
 
     def initialize(url:, index_name:, llm:, api_key: nil, es_options: {})

--- a/lib/langchain/vectorsearch/epsilla.rb
+++ b/lib/langchain/vectorsearch/epsilla.rb
@@ -4,16 +4,16 @@ require "securerandom"
 require "timeout"
 
 module Langchain::Vectorsearch
+  #
+  # Wrapper around Epsilla client library
+  #
+  # Gem requirements:
+  #     gem "epsilla-ruby", "~> 0.0.3"
+  #
+  # Usage:
+  #     epsilla = Langchain::Vectorsearch::Epsilla.new(url:, db_name:, db_path:, index_name:, llm:)
+  #
   class Epsilla < Base
-    #
-    # Wrapper around Epsilla client library
-    #
-    # Gem requirements:
-    #     gem "epsilla-ruby", "~> 0.0.3"
-    #
-    # Usage:
-    #     epsilla = Langchain::Vectorsearch::Epsilla.new(url:, db_name:, db_path:, index_name:, llm:)
-    #
     # Initialize Epsilla client
     # @param url [String] URL to connect to the Epsilla db instance, protocol://host:port
     # @param db_name [String] The name of the database to use

--- a/lib/langchain/vectorsearch/hnswlib.rb
+++ b/lib/langchain/vectorsearch/hnswlib.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 module Langchain::Vectorsearch
+  #
+  # Wrapper around HNSW (Hierarchical Navigable Small World) library.
+  # HNSWLib is an in-memory vectorstore that can be saved to a file on disk.
+  #
+  # Gem requirements:
+  #     gem "hnswlib", "~> 0.8.1"
+  #
+  # Usage:
+  #     hnsw = Langchain::Vectorsearch::Hnswlib.new(llm:, path_to_index:)
+  #
   class Hnswlib < Base
-    #
-    # Wrapper around HNSW (Hierarchical Navigable Small World) library.
-    # HNSWLib is an in-memory vectorstore that can be saved to a file on disk.
-    #
-    # Gem requirements:
-    #     gem "hnswlib", "~> 0.8.1"
-    #
-    # Usage:
-    #     hnsw = Langchain::Vectorsearch::Hnswlib.new(llm:, path_to_index:)
-
     attr_reader :client, :path_to_index
 
     #

--- a/lib/langchain/vectorsearch/milvus.rb
+++ b/lib/langchain/vectorsearch/milvus.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 module Langchain::Vectorsearch
+  #
+  # Wrapper around Milvus REST APIs.
+  #
+  # Gem requirements:
+  #     gem "milvus", "~> 0.10.3"
+  #
+  # Usage:
+  #     milvus = Langchain::Vectorsearch::Milvus.new(url:, index_name:, llm:, api_key:)
+  #
   class Milvus < Base
-    #
-    # Wrapper around Milvus REST APIs.
-    #
-    # Gem requirements:
-    #     gem "milvus", "~> 0.10.3"
-    #
-    # Usage:
-    #     milvus = Langchain::Vectorsearch::Milvus.new(url:, index_name:, llm:, api_key:)
-    #
     def initialize(url:, index_name:, llm:, api_key: nil)
       depends_on "milvus"
 

--- a/lib/langchain/vectorsearch/pgvector.rb
+++ b/lib/langchain/vectorsearch/pgvector.rb
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
 
 module Langchain::Vectorsearch
+  #
+  # The PostgreSQL vector search adapter
+  #
+  # Gem requirements:
+  #     gem "sequel", "~> 5.87.0"
+  #     gem "pgvector", "~> 0.2"
+  #
+  # Usage:
+  #     pgvector = Langchain::Vectorsearch::Pgvector.new(url:, index_name:, llm:, namespace: nil)
+  #
   class Pgvector < Base
-    #
-    # The PostgreSQL vector search adapter
-    #
-    # Gem requirements:
-    #     gem "sequel", "~> 5.87.0"
-    #     gem "pgvector", "~> 0.2"
-    #
-    # Usage:
-    #     pgvector = Langchain::Vectorsearch::Pgvector.new(url:, index_name:, llm:, namespace: nil)
-    #
-
     # The operators supported by the PostgreSQL vector search adapter
     OPERATORS = {
       "cosine_distance" => "cosine",

--- a/lib/langchain/vectorsearch/pinecone.rb
+++ b/lib/langchain/vectorsearch/pinecone.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 module Langchain::Vectorsearch
+  #
+  # Wrapper around Pinecone API.
+  #
+  # Gem requirements:
+  #     gem "pinecone", "~> 0.1.6"
+  #
+  # Usage:
+  #     pinecone = Langchain::Vectorsearch::Pinecone.new(environment:, api_key:, index_name:, llm:)
+  #
   class Pinecone < Base
-    #
-    # Wrapper around Pinecone API.
-    #
-    # Gem requirements:
-    #     gem "pinecone", "~> 0.1.6"
-    #
-    # Usage:
-    #     pinecone = Langchain::Vectorsearch::Pinecone.new(environment:, api_key:, index_name:, llm:)
-    #
-
     # Initialize the Pinecone client
     # @param environment [String] The environment to use
     # @param api_key [String] The API key to use

--- a/lib/langchain/vectorsearch/qdrant.rb
+++ b/lib/langchain/vectorsearch/qdrant.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 module Langchain::Vectorsearch
+  #
+  # Wrapper around Qdrant
+  #
+  # Gem requirements:
+  #     gem "qdrant-ruby", "~> 0.9.8"
+  #
+  # Usage:
+  #     qdrant = Langchain::Vectorsearch::Qdrant.new(url:, api_key:, index_name:, llm:)
+  #
   class Qdrant < Base
-    #
-    # Wrapper around Qdrant
-    #
-    # Gem requirements:
-    #     gem "qdrant-ruby", "~> 0.9.8"
-    #
-    # Usage:
-    #     qdrant = Langchain::Vectorsearch::Qdrant.new(url:, api_key:, index_name:, llm:)
-    #
-
     # Initialize the Qdrant client
     # @param url [String] The URL of the Qdrant server
     # @param api_key [String] The API key to use

--- a/lib/langchain/vectorsearch/weaviate.rb
+++ b/lib/langchain/vectorsearch/weaviate.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 module Langchain::Vectorsearch
+  #
+  # Wrapper around Weaviate
+  #
+  # Gem requirements:
+  #     gem "weaviate-ruby", "~> 0.9.2"
+  #
+  # Usage:
+  #     weaviate = Langchain::Vectorsearch::Weaviate.new(url: ENV["WEAVIATE_URL"], api_key: ENV["WEAVIATE_API_KEY"], index_name: "Docs", llm: llm)
+  #
   class Weaviate < Base
-    #
-    # Wrapper around Weaviate
-    #
-    # Gem requirements:
-    #     gem "weaviate-ruby", "~> 0.9.2"
-    #
-    # Usage:
-    #     weaviate = Langchain::Vectorsearch::Weaviate.new(url: ENV["WEAVIATE_URL"], api_key: ENV["WEAVIATE_API_KEY"], index_name: "Docs", llm: llm)
-    #
-
     # Initialize the Weaviate adapter
     # @param url [String] The URL of the Weaviate instance
     # @param api_key [String] The API key to use


### PR DESCRIPTION
This PR moves documentation for classes under `Langchain::Vectorsearch` module to their proper locations.