### PR TITLE
[Doc] Document deprecated APIs using `@deprecated` tag

### DIFF
--- a/lib/langchain/llm/ai21.rb
+++ b/lib/langchain/llm/ai21.rb
@@ -10,6 +10,7 @@ module Langchain::LLM
   # Usage:
   #     llm = Langchain::LLM::AI21.new(api_key: ENV["AI21_API_KEY"])
   #
+  # @deprecated Use another LLM provider.
   class AI21 < Base
     DEFAULTS = {
       temperature: 0.0,

--- a/lib/langchain/llm/base.rb
+++ b/lib/langchain/llm/base.rb
@@ -26,9 +26,9 @@ module Langchain::LLM
     # Default LLM options. Can be overridden by passing `default_options: {}` to the Langchain::LLM::* constructors.
     attr_reader :defaults
 
-    # Ensuring backward compatibility for `default_dimensions`.
+    # Ensuring backward compatibility for {default_dimensions}.
     #
-    # @deprecated Use `default_dimensions` instead.
+    # @deprecated Use {default_dimensions} instead.
     # @see https://github.com/patterns-ai-core/langchainrb/pull/586
     def default_dimension
       Langchain.logger.warn "DEPRECATED: `default_dimension` is deprecated, and will be removed in the next major version. Please use `default_dimensions` instead."

--- a/lib/langchain/llm/llama_cpp.rb
+++ b/lib/langchain/llm/llama_cpp.rb
@@ -13,6 +13,7 @@ module Langchain::LLM
   #       n_threads: Integer(ENV["LLAMACPP_N_THREADS"])
   #     )
   #
+  # @deprecated Use {Langchain::LLM::Ollama} for self-hosted LLM inference.
   class LlamaCpp < Base
     attr_accessor :model_path, :n_gpu_layers, :n_ctx, :seed
     attr_writer :n_threads

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -98,6 +98,7 @@ module Langchain::LLM
     # @param prompt [String] The prompt to generate a completion for
     # @param params [Hash] The parameters to pass to the `chat()` method
     # @return [Langchain::LLM::OpenAIResponse] Response object
+    # @deprecated Use {chat} instead.
     def complete(prompt:, **params)
       Langchain.logger.warn "DEPRECATED: `Langchain::LLM::OpenAI#complete` is deprecated, and will be removed in the next major version. Use `Langchain::LLM::OpenAI#chat` instead."
 

--- a/lib/langchain/vectorsearch/epsilla.rb
+++ b/lib/langchain/vectorsearch/epsilla.rb
@@ -4,16 +4,18 @@ require "securerandom"
 require "timeout"
 
 module Langchain::Vectorsearch
+  #
+  # Wrapper around Epsilla client library
+  #
+  # Gem requirements:
+  #     gem "epsilla-ruby", "~> 0.0.3"
+  #
+  # Usage:
+  #     epsilla = Langchain::Vectorsearch::Epsilla.new(url:, db_name:, db_path:, index_name:, llm:)
+  #
+  # @deprecated Use other vector storage engines.
+  #
   class Epsilla < Base
-    #
-    # Wrapper around Epsilla client library
-    #
-    # Gem requirements:
-    #     gem "epsilla-ruby", "~> 0.0.3"
-    #
-    # Usage:
-    #     epsilla = Langchain::Vectorsearch::Epsilla.new(url:, db_name:, db_path:, index_name:, llm:)
-    #
     # Initialize Epsilla client
     # @param url [String] URL to connect to the Epsilla db instance, protocol://host:port
     # @param db_name [String] The name of the database to use


### PR DESCRIPTION
This change adds the `@deprecated` YARD tag to several classes and methods.

This makes it possible to explicitly mark the API as deprecated in the YARD documentation. It also updates inline references from backtick-style (`name`) to the link-style (`{name}`) for improved documentation rendering.

<img width="1722" alt="langchain-llm-llamacpp" src="https://github.com/user-attachments/assets/bd1e91dc-1b64-4bbe-a6e9-662ae504a56f" />
