### PR TITLE
Remove unused `extend Forwardable`

### DIFF
--- a/lib/langchain/vectorsearch/base.rb
+++ b/lib/langchain/vectorsearch/base.rb
@@ -86,7 +86,6 @@ module Langchain::Vectorsearch
   #
   class Base
     include Langchain::DependencyHelper
-    extend Forwardable
 
     attr_reader :client, :index_name, :llm
 


### PR DESCRIPTION
The `extend Forwardable` is no longer needed due to #356, and is removed in this PR.