### PR TITLE
fix(ollama): handle incomplete JSON chunks in stream

### DIFF
--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -287,10 +287,28 @@ module Langchain::LLM
     end
 
     def json_responses_chunk_handler(&block)
+      incomplete_chunk_line = nil
       proc do |chunk, _size|
         chunk.split("\n").each do |chunk_line|
-          parsed_chunk = JSON.parse(chunk_line)
-          block.call(parsed_chunk)
+          if incomplete_chunk_line
+            chunk_line = incomplete_chunk_line + chunk_line
+            incomplete_chunk_line = nil
+          end
+
+          parsed_chunk = begin
+            JSON.parse(chunk_line)
+
+            # In some instance the chunk exceeds the buffer size and the JSON parser fails
+          rescue JSON::ParserError
+            unless chunk_line.end_with?("}")
+              incomplete_chunk_line = chunk_line
+              nil
+            else
+              raise
+            end
+          end
+
+          block.call(parsed_chunk) unless parsed_chunk.nil?
         end
       end
     end


### PR DESCRIPTION
Addresses one of the issues raised in https://github.com/patterns-ai-core/langchainrb/issues/686

## Problem
Ollama LLM returns the final chunk in parts when the chunk is too long. I only noticed this behaviour on the final chunk, I'm not sure if it happens on other chunks as well.

## Solution
Improve the `json_responses_chunk_handler` to gracefully handle cases where a JSON chunk is split across buffer boundaries. If a chunk does not end with '}', it is considered incomplete and buffered until the next chunk arrives. This prevents JSON parsing errors and ensures all responses are processed correctly.