### PR TITLE
[Tool - Weather] Ask model to provide country code if location not found and country code is null

### DIFF
--- a/lib/langchain/tool/weather.rb
+++ b/lib/langchain/tool/weather.rb
@@ -58,6 +58,11 @@ module Langchain::Tool
       return tool_response(content: location_response) if location_response.is_a?(String) # Error occurred
 
       location = location_response.first
+      if !location && country_code.nil?
+        return tool_response(content: "Location not found. Please provide a valid country code too and try again.")
+      else
+        return tool_response(content: "Location not found") unless location
+      end
       return tool_response(content: "Location not found") unless location
 
       params = params.merge(lat: location["lat"], lon: location["lon"]).except(:q)

--- a/lib/langchain/version.rb
+++ b/lib/langchain/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Langchain
-  VERSION = "0.19.5"
+  VERSION = "0.19.5-fix"
   Version = VERSION
 end

--- a/spec/lib/langchain/tool/weather_spec.rb
+++ b/spec/lib/langchain/tool/weather_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Langchain::Tool::Weather do
       it "returns an error message" do
         result = weather_tool.get_current_weather(city: city, state_code: state_code)
         expect(result).to be_a(Langchain::ToolResponse)
-        expect(result.content).to eq("Location not found")
+        expect(result.content).to start_with("Location not found")
       end
     end
 


### PR DESCRIPTION
Some times if the country code is not provided, the openweathermap geocoding API will return empty.
for example:
Seattle,WA.
http://api.openweathermap.org/geo/1.0/direct?q=Seattle,WA&appId=<API_KEY>


Ask model to provide a country code and try again.