### PR TITLE
Last message return from OpenAI assistant tools_calls is null

### DIFF
--- a/lib/langchain/assistant.rb
+++ b/lib/langchain/assistant.rb
@@ -309,12 +309,12 @@ module Langchain
     end
 
     def set_state_for(response:)
-      if response.tool_calls.any?
-        :in_progress
-      elsif response.chat_completion
+      if response.chat_completion
         :completed
       elsif response.completion # Currently only used by Ollama
         :completed
+      elsif response.tool_calls.any?
+        :in_progress
       else
         Langchain.logger.error("#{self.class} - LLM response does not contain tool calls, chat or completion response")
         :failed

--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -40,7 +40,7 @@ module Langchain
           # @param tool_call_id [String] The tool call ID
           # @return [Messages::OpenAIMessage] The OpenAI message
           def build_message(role:, content: nil, image_url: nil, tool_calls: [], tool_call_id: nil)
-            Messages::OpenAIMessage.new(role: role, content: content, image_url: image_url, tool_calls: tool_calls, tool_call_id: tool_call_id)
+            Messages::OpenAIMessage.new(role: role, content: content, image_url: image_url, tool_calls: tool_calls || [], tool_call_id: tool_call_id)
           end
 
           # Extract the tool call information from the OpenAI tool call hash


### PR DESCRIPTION
This fix is to address issue #1011 

While writing assistant code that make use of OpenAI. The complete response from openAI message contain "tool_calls":null. Which initialized the tool_calls to nil.

This causes exceptions to be raise because there are multiple places that either make sure or assume tool_calls is an array of hashes