### PR TITLE
Add an exception for GoogleGemini and GoogleVertexAI when using the OutputFixingParser

### DIFF
--- a/spec/lib/langchain/output_parsers/fix_spec.rb
+++ b/spec/lib/langchain/output_parsers/fix_spec.rb
@@ -186,5 +186,26 @@ RSpec.describe Langchain::OutputParsers::OutputFixingParser do
       expect { parser.parse("Whoops I don't understand") }.to raise_error(Langchain::OutputParsers::OutputParserException)
       expect(parser.llm).to have_received(:chat).once
     end
+
+    context "with a Gemini based model" do
+      let(:llm_example) { Langchain::LLM::GoogleGemini.new(api_key: "123") }
+
+      it "parses when the llm is a Gemini based model" do
+        parser = described_class.new(**kwargs_example.merge(prompt: fix_prompt_template_example))
+        expect(parser.llm).to receive(:chat).with({ 
+          messages: [
+            {
+              role: "user",
+              parts: [
+                {
+                  text: match(fix_prompt_matcher_example)
+                }
+              ]
+            }
+          ]
+        }).and_return(double(completion: json_text_response))
+        expect(parser.parse("Whoops I don't understand")).to eq(json_response)
+      end
+    end
   end
 end


### PR DESCRIPTION
Connected to #1015 

As described in the README, the google APIs have a different format for their LLMs:

```
messages = [
  { role: "system", content: "You are a helpful assistant." },
  { role: "user", content: "What's the weather like today?" }
  # Google Gemini and Google VertexAI expect messages in a different format:
  # { role: "user", parts: [{ text: "why is the sky blue?" }]}
]
response = llm.chat(messages: messages)
chat_completion = response.chat_completion
```

And the OutputFixingParser class doesn't work with Gemini 2.5-flash, as it throws the following error:

> {"error"=>{"code"=>400, "message"=>"Invalid JSON payload received. Unknown name "content" at 'contents[0]': Cannot find field.", "status"=>"INVALID_ARGUMENT", "details"=>[{"@type"=>"type.googleapis.com/google.rpc.BadRequest", "fieldViolations"=>[{"field"=>"contents[0]", "description"=>"Invalid JSON payload received. Unknown name "content" at 'contents[0]': Cannot find field."}]}]}}

The goal of this PR is to use the correct format instead.