### PR TITLE
Fix max tokens tool calls function

### DIFF
--- a/lib/langchain/llm/response/google_gemini_response.rb
+++ b/lib/langchain/llm/response/google_gemini_response.rb
@@ -15,7 +15,7 @@ module Langchain::LLM::Response
     end
 
     def tool_calls
-      if raw_response.dig("candidates", 0, "content") && raw_response.dig("candidates", 0, "content", "parts", 0).has_key?("functionCall")
+      if raw_response.dig("candidates", 0, "content", "parts") && raw_response.dig("candidates", 0, "content", "parts", 0).has_key?("functionCall")
         raw_response.dig("candidates", 0, "content", "parts")
       else
         []

--- a/spec/fixtures/llm/google_gemini/chat_with_tool_calls_max_tokens.json
+++ b/spec/fixtures/llm/google_gemini/chat_with_tool_calls_max_tokens.json
@@ -1,0 +1,11 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model"
+      }, 
+      "finishReason": "MAX_TOKENS",
+      "index": 0
+    }
+  ]
+}

--- a/spec/lib/langchain/llm/response/google_gemini_response_spec.rb
+++ b/spec/lib/langchain/llm/response/google_gemini_response_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe Langchain::LLM::Response::GoogleGeminiResponse do
     it "returns tool_calls" do
       expect(response.tool_calls).to eq([{"functionCall" => {"name" => "calculator__execute", "args" => {"input" => "2+2"}}}])
     end
+
+    context 'when output has reached max tokens' do
+      let(:raw_response) {
+        JSON.parse File.read("spec/fixtures/llm/google_gemini/chat_with_tool_calls_max_tokens.json")
+      }
+      let(:response) { described_class.new(raw_response) }
+
+      it "returns tool_calls" do
+        expect(response.tool_calls).to eq([])
+      end
+    end
   end
 
   describe "#embeddings" do


### PR DESCRIPTION
When you use the max_tokens option in google gemini, you get a response that looks like this once the limit is reached:

```
{
  "candidates": [
    {
      "content": {
        "role": "model"
      },
      "finishReason": "MAX_TOKENS",
      "index": 0
    }
  ],
  "usageMetadata": {
    ...
  },
  "modelVersion": "gemini-2.5-flash-lite",
  "responseId": "123"
}
```

Then the `.tool_calls` function fails because `nil` doesn't have a `has_key?` method.