### PR TITLE
Document Tuning Engines with the OpenAI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ llm = Langchain::LLM::OpenAI.new(
 )
 ```
 
+#### OpenAI-compatible gateways
+
+You can route the OpenAI LLM adapter through an OpenAI-compatible gateway by passing the underlying `ruby-openai` client options in `llm_options`. For example, Ruby and Rails apps using [Tuning Engines](https://www.tuningengines.com/) can keep the Langchain.rb interface while centralizing model routing, policy controls, audit logs, traces, approvals, and cost visibility:
+
+```ruby
+llm = Langchain::LLM::OpenAI.new(
+  api_key: ENV["TUNING_ENGINES_API_KEY"],
+  llm_options: {
+    uri_base: "https://api.tuningengines.com/v1"
+  },
+  default_options: {
+    chat_model: ENV.fetch("TUNING_ENGINES_MODEL", "gpt-4o-mini"),
+    embedding_model: ENV.fetch("TUNING_ENGINES_EMBEDDING_MODEL", "text-embedding-3-small")
+  }
+)
+```
+
 ### Generating Embeddings
 
 Use the `embed` method to generate embeddings for given text:

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -14,6 +14,13 @@ module Langchain::LLM
   #      llm_options: {}, # Available options: https://github.com/alexrudall/ruby-openai/blob/main/lib/openai/client.rb#L5-L13
   #      default_options: {}
   #    )
+  #
+  # OpenAI-compatible gateways can be configured through `llm_options`, for example:
+  #    llm = Langchain::LLM::OpenAI.new(
+  #      api_key: ENV["TUNING_ENGINES_API_KEY"],
+  #      llm_options: {uri_base: "https://api.tuningengines.com/v1"},
+  #      default_options: {chat_model: ENV.fetch("TUNING_ENGINES_MODEL", "gpt-4o-mini")}
+  #    )
   class OpenAI < Base
     DEFAULTS = {
       n: 1,


### PR DESCRIPTION
## Summary

- Adds a docs-only example for using Langchain.rb with Tuning Engines through the existing OpenAI-compatible `uri_base` configuration.
- Keeps Langchain.rb APIs and runtime behavior unchanged: no dependency, adapter, or code-path changes.
- Shows a concrete path for Ruby/Rails teams that want to keep Langchain.rb for prompts, chains, tools, and app logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI application code.

Langchain.rb already supports this pattern via `Langchain::LLM::OpenAI` plus `llm_options[:uri_base]`. The proposed docs make that existing capability discoverable for Rails/Ruby teams without adding a new provider, new dependency, or new integration surface.

## Testing

- `git diff --check`
