### PR TITLE
Fix parallel_tool_calls: false for Gemini assistants

### DIFF
--- a/lib/langchain/assistant.rb
+++ b/lib/langchain/assistant.rb
@@ -352,6 +352,15 @@ module Langchain
     #
     # @param tool_calls [Array<Hash>] The tool calls to run
     def run_tools(tool_calls)
+      if parallel_tool_calls == false
+        # Some providers, such as Google Gemini, do not expose an API option
+        # to disable parallel tool calls. Keep the model message in sync with
+        # the single tool response that we submit, then let the next turn
+        # request any remaining tool calls.
+        tool_calls = tool_calls.first(1)
+        messages.last.tool_calls = tool_calls
+      end
+
       # Iterate over each function invocation and submit tool output
       tool_calls.each do |tool_call|
         run_tool(tool_call)

--- a/lib/langchain/assistant/messages/base.rb
+++ b/lib/langchain/assistant/messages/base.rb
@@ -10,6 +10,8 @@ module Langchain
           :tool_calls,
           :tool_call_id
 
+        attr_writer :tool_calls
+
         # Check if the message came from a user
         #
         # @return [Boolean] true/false whether the message came from a user

--- a/spec/lib/langchain/assistant/assistant_spec.rb
+++ b/spec/lib/langchain/assistant/assistant_spec.rb
@@ -953,12 +953,14 @@ RSpec.describe Langchain::Assistant do
     let(:llm) { Langchain::LLM::GoogleGemini.new(api_key: "123") }
     let(:calculator) { Langchain::Tool::Calculator.new }
     let(:instructions) { "You are an expert assistant" }
+    let(:parallel_tool_calls) { true }
 
     subject {
       described_class.new(
         llm: llm,
         tools: [calculator],
-        instructions: instructions
+        instructions: instructions,
+        parallel_tool_calls: parallel_tool_calls
       )
     }
 
@@ -1029,6 +1031,120 @@ RSpec.describe Langchain::Assistant do
 
           expect(subject.messages.last.role).to eq("model")
           expect(subject.messages.last.tool_calls).to eq([raw_google_gemini_response["candidates"][0]["content"]["parts"]][0])
+        end
+      end
+
+      context "when parallel_tool_calls is false" do
+        let(:parallel_tool_calls) { false }
+        let(:raw_google_gemini_response_with_parallel_tool_calls) do
+          {
+            "candidates" => [
+              {
+                "content" => {
+                  "parts" => [
+                    {
+                      "functionCall" => {
+                        "name" => "langchain_tool_calculator__execute",
+                        "args" => {"input" => "2+2"}
+                      }
+                    },
+                    {
+                      "functionCall" => {
+                        "name" => "langchain_tool_calculator__execute",
+                        "args" => {"input" => "3+3"}
+                      }
+                    }
+                  ],
+                  "role" => "model"
+                },
+                "finishReason" => "STOP",
+                "index" => 0,
+                "safetyRatings" => []
+              }
+            ]
+          }
+        end
+
+        let(:raw_google_gemini_response_with_second_tool_call) do
+          {
+            "candidates" => [
+              {
+                "content" => {
+                  "parts" => [
+                    {
+                      "functionCall" => {
+                        "name" => "langchain_tool_calculator__execute",
+                        "args" => {"input" => "3+3"}
+                      }
+                    }
+                  ],
+                  "role" => "model"
+                },
+                "finishReason" => "STOP",
+                "index" => 0,
+                "safetyRatings" => []
+              }
+            ]
+          }
+        end
+
+        let(:raw_google_gemini_final_response) do
+          {
+            "candidates" => [
+              {
+                "content" => {
+                  "parts" => [{"text" => "The answer is 4.0"}],
+                  "role" => "model"
+                },
+                "finishReason" => "STOP",
+                "index" => 0,
+                "safetyRatings" => []
+              }
+            ]
+          }
+        end
+
+        it "serializes tool execution to one call per model turn" do
+          first_tool_call = raw_google_gemini_response_with_parallel_tool_calls["candidates"][0]["content"]["parts"][0]
+          second_tool_call = raw_google_gemini_response_with_second_tool_call["candidates"][0]["content"]["parts"][0]
+          expect(subject.tools[0]).to receive(:execute).with(input: "2+2").and_return("4.0")
+          expect(subject.tools[0]).to receive(:execute).with(input: "3+3").and_return("6.0")
+
+          expect(subject.llm).to receive(:chat).with(
+            messages: [{role: "user", parts: [{text: "Please calculate 2+2 and 3+3"}]}],
+            tools: calculator.class.function_schemas.to_google_gemini_format,
+            tool_choice: {function_calling_config: {mode: "auto"}},
+            system: instructions
+          ).and_return(Langchain::LLM::Response::GoogleGeminiResponse.new(raw_google_gemini_response_with_parallel_tool_calls))
+
+          expect(subject.llm).to receive(:chat).with(
+            messages: [
+              {role: "user", parts: [{text: "Please calculate 2+2 and 3+3"}]},
+              {role: "model", parts: [first_tool_call]},
+              {role: "function", parts: [{functionResponse: {name: "langchain_tool_calculator__execute", response: {name: "langchain_tool_calculator__execute", content: "4.0"}}}]}
+            ],
+            tools: calculator.class.function_schemas.to_google_gemini_format,
+            tool_choice: {function_calling_config: {mode: "auto"}},
+            system: instructions
+          ).and_return(Langchain::LLM::Response::GoogleGeminiResponse.new(raw_google_gemini_response_with_second_tool_call))
+
+          expect(subject.llm).to receive(:chat).with(
+            messages: [
+              {role: "user", parts: [{text: "Please calculate 2+2 and 3+3"}]},
+              {role: "model", parts: [first_tool_call]},
+              {role: "function", parts: [{functionResponse: {name: "langchain_tool_calculator__execute", response: {name: "langchain_tool_calculator__execute", content: "4.0"}}}]},
+              {role: "model", parts: [second_tool_call]},
+              {role: "function", parts: [{functionResponse: {name: "langchain_tool_calculator__execute", response: {name: "langchain_tool_calculator__execute", content: "6.0"}}}]}
+            ],
+            tools: calculator.class.function_schemas.to_google_gemini_format,
+            tool_choice: {function_calling_config: {mode: "auto"}},
+            system: instructions
+          ).and_return(Langchain::LLM::Response::GoogleGeminiResponse.new(raw_google_gemini_final_response))
+
+          subject.add_message_and_run!(content: "Please calculate 2+2 and 3+3")
+
+          expect(subject.messages.last.content).to eq("The answer is 4.0")
+          expect(subject.messages[1].tool_calls).to eq([first_tool_call])
         end
       end
 


### PR DESCRIPTION
## Summary

Fixes #1038.

Google Gemini can return multiple function calls in one model response, but its function-calling configuration does not provide an OpenAI-style `parallel_tool_calls: false` switch. When an assistant was configured with `parallel_tool_calls: false`, Langchain.rb still submitted one tool response for every returned call in the same turn, which could leave Gemini's function-call/response parts out of sync.

This change makes the explicit `false` setting serialize tool execution at the model-turn boundary: the assistant keeps the first tool call on the model message, executes it, and lets the next model turn request the remaining calls. Existing `nil` and `true` behavior is unchanged.

## Validation

- `bundle exec rspec spec/lib/langchain/assistant/assistant_spec.rb --example 'serializes tool execution to one call per model turn' --format documentation` ? 1 example, 0 failures
- Google Gemini assistant context ? 13 examples, 0 failures
- OpenAI assistant context ? 30 examples, 0 failures
- Anthropic assistant context ? 13 examples, 0 failures
- Google Gemini adapter and message specs ? 6 examples, 0 failures
- `bundle exec standardrb` ? passed
- Ruby syntax checks and `git diff --check` ? passed

The full RSpec suite is currently blocked on this Windows environment because the existing `mistral-ai` dependency cannot load the native `libcurl` library while loading `spec/lib/langchain/llm/mistral_ai_spec.rb`; no examples ran in that full-suite invocation. The changed path and neighboring provider contexts pass independently.
