### PR TITLE
docs: update changelog for PR 1040

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [SECURITY]: A change which fixes a security vulnerability.
 
 ## [Unreleased]
+- [BUGFIX] [https://github.com/patterns-ai-core/langchainrb/pull/1040] Fix `parallel_tool_calls: false` for Google Gemini assistants by serializing tool execution across model turns.
 - [COMPAT] [https://github.com/patterns-ai-core/langchainrb/pull/980] Suppress a Ruby 3.4 warning for URI parser.
 - [BREAKING] [https://github.com/patterns-ai-core/langchainrb/pull/997] Remove `Langchain::Vectorsearch::Epsilla` class
 - [BREAKING] [https://github.com/patterns-ai-core/langchainrb/pull/1003] Response classes are now namespaced under `Langchain::LLM::Response`, converted to Rails engine


### PR DESCRIPTION
## Summary

- Add a CHANGELOG entry for the merged PR #1040.
- Document the Gemini fix for parallel_tool_calls: false.

## Validation

- git diff --check passed.
- Ruby/Bundler checks were not run because Ruby and Bundler are unavailable in the local environment.

Related to #1040.